### PR TITLE
✨애플 로그인 기초 구현 및 MessageKit을 삭제 후 이슈들을 해결했습니다.

### DIFF
--- a/Flicker.xcodeproj/project.pbxproj
+++ b/Flicker.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		1066BFE729097BB2000B8555 /* KeychainItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1066BFE629097BB2000B8555 /* KeychainItem.swift */; };
 		10FE6B6029064FE60064201F /* FirebaseAuth in Frameworks */ = {isa = PBXBuildFile; productRef = 10FE6B5F29064FE60064201F /* FirebaseAuth */; };
 		10FE6B6229064FE60064201F /* FirebaseFirestore in Frameworks */ = {isa = PBXBuildFile; productRef = 10FE6B6129064FE60064201F /* FirebaseFirestore */; };
 		10FE6B6429064FE60064201F /* FirebaseFirestoreSwift in Frameworks */ = {isa = PBXBuildFile; productRef = 10FE6B6329064FE60064201F /* FirebaseFirestoreSwift */; };
@@ -15,7 +16,6 @@
 		10FE6B6B290651150064201F /* Lottie in Frameworks */ = {isa = PBXBuildFile; productRef = 10FE6B6A290651150064201F /* Lottie */; };
 		10FE6B6E290651630064201F /* SnapKit in Frameworks */ = {isa = PBXBuildFile; productRef = 10FE6B6D290651630064201F /* SnapKit */; };
 		10FE6B712906519E0064201F /* Then in Frameworks */ = {isa = PBXBuildFile; productRef = 10FE6B702906519E0064201F /* Then */; };
-		10FE6B74290651E10064201F /* MessageKit in Frameworks */ = {isa = PBXBuildFile; productRef = 10FE6B73290651E10064201F /* MessageKit */; };
 		CB33C1D1290621C200F37626 /* GoogleService-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = CB33C1D0290621C200F37626 /* GoogleService-Info.plist */; };
 		CBDC03D429060E6600C6CF30 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = CBDC03D329060E6600C6CF30 /* AppDelegate.swift */; };
 		CBDC03D629060E6600C6CF30 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = CBDC03D529060E6600C6CF30 /* SceneDelegate.swift */; };
@@ -58,6 +58,7 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
+		1066BFE629097BB2000B8555 /* KeychainItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeychainItem.swift; sourceTree = "<group>"; };
 		CB33C1CF2906214200F37626 /* Flicker.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = Flicker.entitlements; sourceTree = "<group>"; };
 		CB33C1D0290621C200F37626 /* GoogleService-Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = "GoogleService-Info.plist"; sourceTree = "<group>"; };
 		CBDC03D029060E6600C6CF30 /* Flicker.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Flicker.app; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -110,7 +111,6 @@
 				10FE6B6629064FE60064201F /* FirebaseMessaging in Frameworks */,
 				10FE6B6829064FE60064201F /* FirebaseStorage in Frameworks */,
 				10FE6B6029064FE60064201F /* FirebaseAuth in Frameworks */,
-				10FE6B74290651E10064201F /* MessageKit in Frameworks */,
 				10FE6B712906519E0064201F /* Then in Frameworks */,
 				10FE6B6E290651630064201F /* SnapKit in Frameworks */,
 				10FE6B6429064FE60064201F /* FirebaseFirestoreSwift in Frameworks */,
@@ -293,6 +293,7 @@
 			isa = PBXGroup;
 			children = (
 				CBDC042B2906125A00C6CF30 /* LoginViewController.swift */,
+				1066BFE629097BB2000B8555 /* KeychainItem.swift */,
 			);
 			path = Login;
 			sourceTree = "<group>";
@@ -379,7 +380,6 @@
 				10FE6B6A290651150064201F /* Lottie */,
 				10FE6B6D290651630064201F /* SnapKit */,
 				10FE6B702906519E0064201F /* Then */,
-				10FE6B73290651E10064201F /* MessageKit */,
 			);
 			productName = Flicker;
 			productReference = CBDC03D029060E6600C6CF30 /* Flicker.app */;
@@ -414,7 +414,6 @@
 				10FE6B69290651150064201F /* XCRemoteSwiftPackageReference "lottie-ios" */,
 				10FE6B6C290651620064201F /* XCRemoteSwiftPackageReference "SnapKit" */,
 				10FE6B6F2906519E0064201F /* XCRemoteSwiftPackageReference "Then" */,
-				10FE6B72290651E00064201F /* XCRemoteSwiftPackageReference "MessageKit" */,
 			);
 			productRefGroup = CBDC03D129060E6600C6CF30 /* Products */;
 			projectDirPath = "";
@@ -473,6 +472,7 @@
 				CBDC03D629060E6600C6CF30 /* SceneDelegate.swift in Sources */,
 				CBDC0431290612FC00C6CF30 /* MessageViewController.swift in Sources */,
 				CBDC04372906133100C6CF30 /* MessageTableViewCell.swift in Sources */,
+				1066BFE729097BB2000B8555 /* KeychainItem.swift in Sources */,
 				CBDC04242906121400C6CF30 /* Sender.swift in Sources */,
 				CBDC04332906130E00C6CF30 /* MessageRoomViewController.swift in Sources */,
 				CBDC03F529060F3400C6CF30 /* BaseCollectionViewCell.swift in Sources */,
@@ -637,7 +637,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.dime.Flicker;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
-				"PROVISIONING_PROFILE_SPECIFIER[sdk=iphoneos*]" = Flicker;
+				"PROVISIONING_PROFILE_SPECIFIER[sdk=iphoneos*]" = FlickerProvisioning;
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
 				SUPPORTS_MACCATALYST = NO;
 				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = NO;
@@ -674,7 +674,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.dime.Flicker;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
-				"PROVISIONING_PROFILE_SPECIFIER[sdk=iphoneos*]" = Flicker;
+				"PROVISIONING_PROFILE_SPECIFIER[sdk=iphoneos*]" = FlickerProvisioning;
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
 				SUPPORTS_MACCATALYST = NO;
 				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = NO;
@@ -740,14 +740,6 @@
 				minimumVersion = 3.0.0;
 			};
 		};
-		10FE6B72290651E00064201F /* XCRemoteSwiftPackageReference "MessageKit" */ = {
-			isa = XCRemoteSwiftPackageReference;
-			repositoryURL = "https://github.com/MessageKit/MessageKit";
-			requirement = {
-				kind = upToNextMajorVersion;
-				minimumVersion = 4.0.0;
-			};
-		};
 /* End XCRemoteSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
@@ -790,11 +782,6 @@
 			isa = XCSwiftPackageProductDependency;
 			package = 10FE6B6F2906519E0064201F /* XCRemoteSwiftPackageReference "Then" */;
 			productName = Then;
-		};
-		10FE6B73290651E10064201F /* MessageKit */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = 10FE6B72290651E00064201F /* XCRemoteSwiftPackageReference "MessageKit" */;
-			productName = MessageKit;
 		};
 /* End XCSwiftPackageProductDependency section */
 	};

--- a/Flicker.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Flicker.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -73,15 +73,6 @@
       }
     },
     {
-      "identity" : "inputbaraccessoryview",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/nathantannar4/InputBarAccessoryView",
-      "state" : {
-        "revision" : "0c4431a7f765ecb81dd97615023ff858bf65f89c",
-        "version" : "6.1.1"
-      }
-    },
-    {
       "identity" : "leveldb",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/firebase/leveldb.git",
@@ -97,15 +88,6 @@
       "state" : {
         "revision" : "b4bd0604ded9574807f41b4004b57dd1226a30a4",
         "version" : "3.5.0"
-      }
-    },
-    {
-      "identity" : "messagekit",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/MessageKit/MessageKit.git",
-      "state" : {
-        "revision" : "14bfa7eb9f93267c3d7b8cdf58615bba27be672a",
-        "version" : "4.1.1"
       }
     },
     {

--- a/Flicker/Flicker.entitlements
+++ b/Flicker/Flicker.entitlements
@@ -4,5 +4,9 @@
 <dict>
 	<key>aps-environment</key>
 	<string>development</string>
+	<key>com.apple.developer.applesignin</key>
+	<array>
+		<string>Default</string>
+	</array>
 </dict>
 </plist>

--- a/Flicker/Global/Supports/AppDelegate.swift
+++ b/Flicker/Global/Supports/AppDelegate.swift
@@ -28,10 +28,10 @@ class AppDelegate: UIResponder, UIApplicationDelegate, MessagingDelegate, UNUser
             switch credentialState {
             case .authorized:
                 print("1")
-                break // The Apple ID credential is valid.
+                break // 이미 로그인을 했으면 넘어가는 로직
             case .revoked, .notFound:
                 print("2")
-                // The Apple ID credential is either revoked or was not found, so show the sign-in UI.
+                // 로그인이 되어있지 않으면 로그인뷰로 이동
                 DispatchQueue.main.async {
                     print("3")
                     self.window?.rootViewController = AuthController

--- a/Flicker/Global/Supports/AppDelegate.swift
+++ b/Flicker/Global/Supports/AppDelegate.swift
@@ -10,27 +10,51 @@ import UIKit
 import Firebase
 import FirebaseMessaging
 import UserNotifications
+import AuthenticationServices
 
 @main
 class AppDelegate: UIResponder, UIApplicationDelegate, MessagingDelegate, UNUserNotificationCenterDelegate {
-    
+    var window: UIWindow?
     var userToken: String = ""
 
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
-        FirebaseApp.configure()
+        let AuthController = UINavigationController(rootViewController: LogInViewController())
         
-        Messaging.messaging().delegate = self
-        UNUserNotificationCenter.current().delegate = self
-        
-        UNUserNotificationCenter.current().requestAuthorization(options: [.alert, .sound, .badge]) { success, _ in
-            guard success else {
-                return
+        let appleIDProvider = ASAuthorizationAppleIDProvider()
+        appleIDProvider.getCredentialState(forUserID: KeychainItem.currentUserIdentifier) { (credentialState, error) in
+            if let error = error {
+                print(error)
             }
-            
-            print("Success in APNS registry")
+            switch credentialState {
+            case .authorized:
+                print("1")
+                break // The Apple ID credential is valid.
+            case .revoked, .notFound:
+                print("2")
+                // The Apple ID credential is either revoked or was not found, so show the sign-in UI.
+                DispatchQueue.main.async {
+                    print("3")
+                    self.window?.rootViewController = AuthController
+                }
+            default:
+                break
+            }
+            print("4")
         }
-        
-        application.registerForRemoteNotifications()
+        FirebaseApp.configure()
+//
+//        Messaging.messaging().delegate = self
+//        UNUserNotificationCenter.current().delegate = self
+//
+//        UNUserNotificationCenter.current().requestAuthorization(options: [.alert, .sound, .badge]) { success, _ in
+//            guard success else {
+//                return
+//            }
+//
+//            print("Success in APNS registry")
+//        }
+//
+//        application.registerForRemoteNotifications()
         
         return true
     }

--- a/Flicker/Models/Message/ImageMediaItem.swift
+++ b/Flicker/Models/Message/ImageMediaItem.swift
@@ -4,20 +4,20 @@
 //
 //  Created by COBY_PRO on 2022/10/24.
 //
-
-import UIKit
-
-import MessageKit
-
-struct ImageMediaItem: MediaItem {
-    var url: URL?
-    var image: UIImage?
-    var placeholderImage: UIImage
-    var size: CGSize
-    
-    init(image: UIImage) {
-        self.image = image
-        self.size = CGSize(width: 240, height: 240)
-        self.placeholderImage = UIImage()
-    }
-}
+//
+//import UIKit
+//
+//import MessageKit
+//
+//struct ImageMediaItem: MediaItem {
+//    var url: URL?
+//    var image: UIImage?
+//    var placeholderImage: UIImage
+//    var size: CGSize
+//    
+//    init(image: UIImage) {
+//        self.image = image
+//        self.size = CGSize(width: 240, height: 240)
+//        self.placeholderImage = UIImage()
+//    }
+//}

--- a/Flicker/Models/Message/Message.swift
+++ b/Flicker/Models/Message/Message.swift
@@ -5,54 +5,54 @@
 //  Created by COBY_PRO on 2022/10/24.
 //
 
-import UIKit
-
-import MessageKit
-
-struct Message: MessageType {
-    
-    let id: String?
-    var messageId: String {
-        return id ?? UUID().uuidString
-    }
-    let content: String
-    let sentDate: Date
-    let sender: SenderType
-    var kind: MessageKind {
-        if let image = image {
-            let mediaItem = ImageMediaItem(image: image)
-            return .photo(mediaItem)
-        } else {
-            return .text(content)
-        }
-    }
-    
-    var image: UIImage?
-    var downloadURL: URL?
-    
-    init(content: String) {
-        sender = Sender(senderId: "coby5502", displayName: "코비코비")
-        self.content = content
-        sentDate = Date()
-        id = nil
-    }
-    
-    init(image: UIImage) {
-        sender = Sender(senderId: "coby5502", displayName: "코비코비")
-        self.image = image
-        sentDate = Date()
-        content = ""
-        id = nil
-    }
-    
-}
-
-extension Message: Comparable {
-    static func == (lhs: Message, rhs: Message) -> Bool {
-        return lhs.id == rhs.id
-    }
-    
-    static func < (lhs: Message, rhs: Message) -> Bool {
-        return lhs.sentDate < rhs.sentDate
-    }
-}
+//import UIKit
+//
+//import MessageKit
+//
+//struct Message: MessageType {
+//    
+//    let id: String?
+//    var messageId: String {
+//        return id ?? UUID().uuidString
+//    }
+//    let content: String
+//    let sentDate: Date
+//    let sender: SenderType
+//    var kind: MessageKind {
+//        if let image = image {
+//            let mediaItem = ImageMediaItem(image: image)
+//            return .photo(mediaItem)
+//        } else {
+//            return .text(content)
+//        }
+//    }
+//    
+//    var image: UIImage?
+//    var downloadURL: URL?
+//    
+//    init(content: String) {
+//        sender = Sender(senderId: "coby5502", displayName: "코비코비")
+//        self.content = content
+//        sentDate = Date()
+//        id = nil
+//    }
+//    
+//    init(image: UIImage) {
+//        sender = Sender(senderId: "coby5502", displayName: "코비코비")
+//        self.image = image
+//        sentDate = Date()
+//        content = ""
+//        id = nil
+//    }
+//    
+//}
+//
+//extension Message: Comparable {
+//    static func == (lhs: Message, rhs: Message) -> Bool {
+//        return lhs.id == rhs.id
+//    }
+//    
+//    static func < (lhs: Message, rhs: Message) -> Bool {
+//        return lhs.sentDate < rhs.sentDate
+//    }
+//}

--- a/Flicker/Models/Message/Sender.swift
+++ b/Flicker/Models/Message/Sender.swift
@@ -5,9 +5,9 @@
 //  Created by COBY_PRO on 2022/10/24.
 //
 
-import MessageKit
-
-struct Sender: SenderType {
-    var senderId: String
-    var displayName: String
-}
+//import MessageKit
+//
+//struct Sender: SenderType {
+//    var senderId: String
+//    var displayName: String
+//}

--- a/Flicker/Screens/Login/KeychainItem.swift
+++ b/Flicker/Screens/Login/KeychainItem.swift
@@ -1,0 +1,149 @@
+//
+//  KeychainItem.swift
+//  Flicker
+//
+//  Created by 김연호 on 2022/10/26.
+//
+
+import Foundation
+
+struct KeychainItem {
+    // MARK: Types
+
+    enum KeychainError: Error {
+        case noPassword
+        case unexpectedPasswordData
+        case unexpectedItemData
+        case unhandledError
+    }
+
+    // MARK: Properties
+
+    let service: String
+
+    private(set) var account: String
+
+    let accessGroup: String?
+
+    // MARK: Intialization
+
+    init(service: String, account: String, accessGroup: String? = nil) {
+        self.service = service
+        self.account = account
+        self.accessGroup = accessGroup
+    }
+
+    // MARK: Keychain access
+
+    func readItem() throws -> String {
+        /*
+         Build a query to find the item that matches the service, account and
+         access group.
+         */
+        var query = KeychainItem.keychainQuery(withService: service, account: account, accessGroup: accessGroup)
+        query[kSecMatchLimit as String] = kSecMatchLimitOne
+        query[kSecReturnAttributes as String] = kCFBooleanTrue
+        query[kSecReturnData as String] = kCFBooleanTrue
+
+        // Try to fetch the existing keychain item that matches the query.
+        var queryResult: AnyObject?
+        let status = withUnsafeMutablePointer(to: &queryResult) {
+            SecItemCopyMatching(query as CFDictionary, UnsafeMutablePointer($0))
+        }
+
+        // Check the return status and throw an error if appropriate.
+        guard status != errSecItemNotFound else { throw KeychainError.noPassword }
+        guard status == noErr else { throw KeychainError.unhandledError }
+
+        // Parse the password string from the query result.
+        guard let existingItem = queryResult as? [String: AnyObject],
+            let passwordData = existingItem[kSecValueData as String] as? Data,
+            let password = String(data: passwordData, encoding: String.Encoding.utf8)
+            else {
+                throw KeychainError.unexpectedPasswordData
+        }
+
+        return password
+    }
+
+    func saveItem(_ password: String) throws {
+        // Encode the password into an Data object.
+        let encodedPassword = password.data(using: String.Encoding.utf8)!
+
+        do {
+            // Check for an existing item in the keychain.
+            try _ = readItem()
+
+            // Update the existing item with the new password.
+            var attributesToUpdate = [String: AnyObject]()
+            attributesToUpdate[kSecValueData as String] = encodedPassword as AnyObject?
+
+            let query = KeychainItem.keychainQuery(withService: service, account: account, accessGroup: accessGroup)
+            let status = SecItemUpdate(query as CFDictionary, attributesToUpdate as CFDictionary)
+
+            // Throw an error if an unexpected status was returned.
+            guard status == noErr else { throw KeychainError.unhandledError }
+        } catch KeychainError.noPassword {
+            /*
+             No password was found in the keychain. Create a dictionary to save
+             as a new keychain item.
+             */
+            var newItem = KeychainItem.keychainQuery(withService: service, account: account, accessGroup: accessGroup)
+            newItem[kSecValueData as String] = encodedPassword as AnyObject?
+
+            // Add a the new item to the keychain.
+            let status = SecItemAdd(newItem as CFDictionary, nil)
+
+            // Throw an error if an unexpected status was returned.
+            guard status == noErr else { throw KeychainError.unhandledError }
+        }
+    }
+
+    func deleteItem() throws {
+        // Delete the existing item from the keychain.
+        let query = KeychainItem.keychainQuery(withService: service, account: account, accessGroup: accessGroup)
+        let status = SecItemDelete(query as CFDictionary)
+
+        // Throw an error if an unexpected status was returned.
+        guard status == noErr || status == errSecItemNotFound else { throw KeychainError.unhandledError }
+    }
+
+    // MARK: Convenience
+
+    private static func keychainQuery(withService service: String, account: String? = nil, accessGroup: String? = nil) -> [String: AnyObject] {
+        var query = [String: AnyObject]()
+        query[kSecClass as String] = kSecClassGenericPassword
+        query[kSecAttrService as String] = service as AnyObject?
+
+        if let account = account {
+            query[kSecAttrAccount as String] = account as AnyObject?
+        }
+
+        if let accessGroup = accessGroup {
+            query[kSecAttrAccessGroup as String] = accessGroup as AnyObject?
+        }
+
+        return query
+    }
+
+    /*
+     For the purpose of this demo app, the user identifier will be stored in the device keychain.
+     You should store the user identifier in your account management system.
+     */
+    static var currentUserIdentifier: String {
+        do {
+            let storedIdentifier = try KeychainItem(service: "com.dime.Flicker", account: "userIdentifier").readItem()
+            return storedIdentifier
+        } catch {
+            return ""
+        }
+    }
+
+    static func deleteUserIdentifierFromKeychain() {
+        do {
+            try KeychainItem(service: "com.dime.Flicker", account: "userIdentifier").deleteItem()
+        } catch {
+            print("Unable to delete userIdentifier from keychain")
+        }
+    }
+}

--- a/Flicker/Screens/Login/LoginViewController.swift
+++ b/Flicker/Screens/Login/LoginViewController.swift
@@ -9,109 +9,122 @@ import UIKit
 
 import SnapKit
 import Then
+import AuthenticationServices
 
 class LogInViewController: BaseViewController {
-    
-    private let loginLabel = UILabel().then {
-        $0.textAlignment = .center
-        $0.text = "로그인"
-        $0.font = .systemFont(ofSize: 24, weight: .semibold)
+
+    private let appleLoginButton = ASAuthorizationAppleIDButton(type: .signIn, style: .whiteOutline).then {
+        $0.addTarget(self, action: #selector(handleAuthorizationAppleIDButtonPress), for: .touchUpInside)
     }
     
-    private let emailField = UITextField().then {
-        let attributes = [
-            NSAttributedString.Key.foregroundColor : UIColor.mainBlack,
-            NSAttributedString.Key.font : UIFont.systemFont(ofSize: 17, weight: .regular)
-        ]
-        
-        $0.backgroundColor = .white
-        $0.attributedPlaceholder = NSAttributedString(string: "Email", attributes: attributes)
-        $0.autocapitalizationType = .none
-        $0.layer.cornerRadius = 12
-        $0.layer.masksToBounds = true
-        $0.leftView = UIView(frame: CGRect(x: 0, y: 0, width: 10, height: 0))
-        $0.leftViewMode = .always
-        $0.clipsToBounds = false
-        $0.makeShadow(color: .black, opacity: 0.08, offset: CGSize(width: 0, height: 4), radius: 20)
-    }
+//    private let loginLabel = UILabel().then {
+//        $0.textAlignment = .center
+//        $0.text = "로그인"
+//        $0.font = .systemFont(ofSize: 24, weight: .semibold)
+//    }
     
-    private let passwordField = UITextField().then {
-        let attributes = [
-            NSAttributedString.Key.foregroundColor : UIColor.mainBlack,
-            NSAttributedString.Key.font : UIFont.systemFont(ofSize: 17, weight: .regular)
-        ]
-        
-        $0.backgroundColor = .white
-        $0.attributedPlaceholder = NSAttributedString(string: "Password", attributes: attributes)
-        $0.layer.cornerRadius = 12
-        $0.layer.masksToBounds = true
-        $0.leftView = UIView(frame: CGRect(x: 0, y: 0, width: 10, height: 0))
-        $0.leftViewMode = .always
-        $0.clipsToBounds = false
-        $0.isSecureTextEntry = true
-        $0.makeShadow(color: .black, opacity: 0.08, offset: CGSize(width: 0, height: 4), radius: 20)
-    }
+//    private let emailField = UITextField().then {
+//        let attributes = [
+//            NSAttributedString.Key.foregroundColor : UIColor.mainBlack,
+//            NSAttributedString.Key.font : UIFont.systemFont(ofSize: 17, weight: .regular)
+//        ]
+//
+//        $0.backgroundColor = .white
+//        $0.attributedPlaceholder = NSAttributedString(string: "Email", attributes: attributes)
+//        $0.autocapitalizationType = .none
+//        $0.layer.cornerRadius = 12
+//        $0.layer.masksToBounds = true
+//        $0.leftView = UIView(frame: CGRect(x: 0, y: 0, width: 10, height: 0))
+//        $0.leftViewMode = .always
+//        $0.clipsToBounds = false
+//        $0.makeShadow(color: .black, opacity: 0.08, offset: CGSize(width: 0, height: 4), radius: 20)
+//    }
     
-    private let logInbutton = UIButton().then {
-        $0.backgroundColor = .mainBlack
-        $0.setTitleColor(.white, for: .normal)
-        $0.setTitle("Log In", for: .normal)
-    }
-        
-    private let signUpButton = UIButton().then {
-        $0.backgroundColor = .mainBlack
-        $0.setTitleColor(.white, for: .normal)
-        $0.setTitle("Sign Up", for: .normal)
-    }
+//    private let passwordField = UITextField().then {
+//        let attributes = [
+//            NSAttributedString.Key.foregroundColor : UIColor.mainBlack,
+//            NSAttributedString.Key.font : UIFont.systemFont(ofSize: 17, weight: .regular)
+//        ]
+//
+//        $0.backgroundColor = .white
+//        $0.attributedPlaceholder = NSAttributedString(string: "Password", attributes: attributes)
+//        $0.layer.cornerRadius = 12
+//        $0.layer.masksToBounds = true
+//        $0.leftView = UIView(frame: CGRect(x: 0, y: 0, width: 10, height: 0))
+//        $0.leftViewMode = .always
+//        $0.clipsToBounds = false
+//        $0.isSecureTextEntry = true
+//        $0.makeShadow(color: .black, opacity: 0.08, offset: CGSize(width: 0, height: 4), radius: 20)
+//    }
     
-    private let logInErrorLabel = UILabel().then {
-        $0.textAlignment = .center
-        $0.text = "Failed to Log In"
-        $0.font = .systemFont(ofSize: 24, weight: .semibold)
-        $0.textColor = .mainBlack
-    }
+//    private let logInbutton = UIButton().then {
+//        $0.backgroundColor = .mainBlack
+//        $0.setTitleColor(.white, for: .normal)
+//        $0.setTitle("Log In", for: .normal)
+//    }
+//
+//    private let signUpButton = UIButton().then {
+//        $0.backgroundColor = .mainBlack
+//        $0.setTitleColor(.white, for: .normal)
+//        $0.setTitle("Sign Up", for: .normal)
+//    }
+    
+//    private let logInErrorLabel = UILabel().then {
+//        $0.textAlignment = .center
+//        $0.text = "Failed to Log In"
+//        $0.font = .systemFont(ofSize: 24, weight: .semibold)
+//        $0.textColor = .mainBlack
+//    }
     
     override func render() {
-        view.addSubviews(loginLabel, emailField, passwordField, logInbutton, signUpButton, logInErrorLabel)
-        
-        logInbutton.addTarget(self, action: #selector(didTapLogInbutton), for: .touchUpInside)
-        signUpButton.addTarget(self, action: #selector(didTapSignUpButton), for: .touchUpInside)
-        
-        logInErrorLabel.isHidden = true
-        
-        loginLabel.snp.makeConstraints {
-            $0.top.equalTo(view.safeAreaLayoutGuide.snp.top).inset(30)
-            $0.leading.trailing.equalToSuperview()
-        }
-        
-        emailField.snp.makeConstraints {
-            $0.top.equalTo(loginLabel.snp.bottom).offset(50)
+//        view.addSubviews(loginLabel, emailField, passwordField, logInbutton, signUpButton, logInErrorLabel)
+
+        view.addSubview(appleLoginButton)
+
+//        logInbutton.addTarget(self, action: #selector(didTapLogInbutton), for: .touchUpInside)
+//        signUpButton.addTarget(self, action: #selector(didTapSignUpButton), for: .touchUpInside)
+//
+//        logInErrorLabel.isHidden = true
+
+        appleLoginButton.snp.makeConstraints {
+            $0.center.equalToSuperview()
             $0.leading.trailing.equalToSuperview().inset(20)
             $0.height.equalTo(60)
         }
+
+//        loginLabel.snp.makeConstraints {
+//            $0.top.equalTo(view.safeAreaLayoutGuide.snp.top).inset(30)
+//            $0.leading.trailing.equalToSuperview()
+//        }
+//
+//        emailField.snp.makeConstraints {
+//            $0.top.equalTo(loginLabel.snp.bottom).offset(50)
+//            $0.leading.trailing.equalToSuperview().inset(20)
+//            $0.height.equalTo(60)
+//        }
+//
+//        passwordField.snp.makeConstraints {
+//            $0.top.equalTo(emailField.snp.bottom).offset(10)
+//            $0.leading.trailing.equalToSuperview().inset(20)
+//            $0.height.equalTo(60)
+//        }
+//
+//        logInbutton.snp.makeConstraints {
+//            $0.top.equalTo(passwordField.snp.bottom).offset(20)
+//            $0.leading.trailing.equalToSuperview().inset(20)
+//            $0.height.equalTo(60)
+//        }
+//
+//        signUpButton.snp.makeConstraints {
+//            $0.top.equalTo(logInbutton.snp.bottom).offset(10)
+//            $0.leading.trailing.equalToSuperview().inset(20)
+//            $0.height.equalTo(60)
+//        }
         
-        passwordField.snp.makeConstraints {
-            $0.top.equalTo(emailField.snp.bottom).offset(10)
-            $0.leading.trailing.equalToSuperview().inset(20)
-            $0.height.equalTo(60)
-        }
-        
-        logInbutton.snp.makeConstraints {
-            $0.top.equalTo(passwordField.snp.bottom).offset(20)
-            $0.leading.trailing.equalToSuperview().inset(20)
-            $0.height.equalTo(60)
-        }
-        
-        signUpButton.snp.makeConstraints {
-            $0.top.equalTo(logInbutton.snp.bottom).offset(10)
-            $0.leading.trailing.equalToSuperview().inset(20)
-            $0.height.equalTo(60)
-        }
-        
-        logInErrorLabel.snp.makeConstraints {
-            $0.top.equalTo(signUpButton.snp.bottom).offset(30)
-            $0.leading.trailing.equalToSuperview().inset(20)
-        }
+//        logInErrorLabel.snp.makeConstraints {
+//            $0.top.equalTo(signUpButton.snp.bottom).offset(30)
+//            $0.leading.trailing.equalToSuperview().inset(20)
+//        }
     }
     
     override func setupNavigationBar() {
@@ -121,31 +134,31 @@ class LogInViewController: BaseViewController {
     
     override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
-        emailField.becomeFirstResponder()
+//        emailField.becomeFirstResponder()
     }
     
-    @objc private func didTapLogInbutton() {
-        guard let email = emailField.text, !email.isEmpty,
-              let password = passwordField.text, !password.isEmpty else {
-            logInErrorLabel.isHidden = false
-            print("Missing field data")
-            return
-        }
-        
-        Task { [weak self] in
-            guard let userId = await FirebaseManager.shared.signInUser(email: email, password: password) else {
-                self?.logInErrorLabel.isHidden = false
-                return
-            }
-            await FirebaseManager.shared.updateUserToken(uid: userId)
-            self?.goHome()
-        }
-    }
+//    @objc private func didTapLogInbutton() {
+//        guard let email = emailField.text, !email.isEmpty,
+//              let password = passwordField.text, !password.isEmpty else {
+//            logInErrorLabel.isHidden = false
+//            print("Missing field data")
+//            return
+//        }
+//
+//        Task { [weak self] in
+//            guard let userId = await FirebaseManager.shared.signInUser(email: email, password: password) else {
+//                self?.logInErrorLabel.isHidden = false
+//                return
+//            }
+//            await FirebaseManager.shared.updateUserToken(uid: userId)
+//            self?.goHome()
+//        }
+//    }
     
-    @objc private func didTapSignUpButton() {
-        let viewController = SignUpViewController()
-        self.navigationController?.pushViewController(viewController, animated: true)
-    }
+//    @objc private func didTapSignUpButton() {
+//        let viewController = SignUpViewController()
+//        self.navigationController?.pushViewController(viewController, animated: true)
+//    }
     
     private func goHome() {
         let viewController = TabbarViewController()
@@ -153,5 +166,62 @@ class LogInViewController: BaseViewController {
         navigationController.modalPresentationStyle = .fullScreen
         self.present(navigationController, animated: true, completion: nil)
     }
+    
+    //Apple ID 승인 요청
+    @objc private func handleAuthorizationAppleIDButtonPress() {
+        let appleIDProvider = ASAuthorizationAppleIDProvider()
+        let request = appleIDProvider.createRequest()
+        //애플에서 제공받을 수 있도록 요청할 수 있는건 이름과 이메일 뿐임
+        request.requestedScopes = [.fullName, .email]
 
+        let authorizationController = ASAuthorizationController(authorizationRequests: [request])
+        authorizationController.delegate = self
+        authorizationController.presentationContextProvider = self
+        authorizationController.performRequests()
+    }
+
+}
+
+extension LogInViewController: ASAuthorizationControllerDelegate, ASAuthorizationControllerPresentationContextProviding {
+
+    func presentationAnchor(for controller: ASAuthorizationController) -> ASPresentationAnchor {
+        return self.view.window!
+    }
+
+
+// 사용자 인증 후 처리
+    func authorizationController(controller: ASAuthorizationController, didCompleteWithAuthorization authorization: ASAuthorization) {
+        switch authorization.credential {
+            //비밀번호 및 페이스ID인증
+        case let appleIDCredential as ASAuthorizationAppleIDCredential:
+            // 앱 내부의 계정에서 사용하는 값
+            let userIdentifier = appleIDCredential.user
+            let fullName = appleIDCredential.fullName
+            let email = appleIDCredential.email
+            saveUserInKeychain(userIdentifier)
+            self.goHome()
+
+            //iCloud의 패스워드 연동
+        case let passwordCredental as ASPasswordCredential:
+            let username = passwordCredental.user
+            let password = passwordCredental.password
+            self.goHome()
+
+        default:
+            break
+        }
+    }
+// 사용자 인증 실패 시
+    func authorizationController(controller: ASAuthorizationController, didCompleteWithError error: Error) {
+        print("인증이 실패 되었습니다.")
+        // TODO: 다시 로그인 뷰가 로딩되어 돌아가는 로직 구현?
+    }
+
+    private func saveUserInKeychain(_ userIdentifier: String) {
+        do {
+            try KeychainItem(service: "com.dime.Flicker", account: "userIdentifier").saveItem(userIdentifier)
+        } catch {
+            print("Unable to save userIdentifier to keychain.")
+        }
+    }
 }

--- a/Flicker/Screens/Main/MainViewController.swift
+++ b/Flicker/Screens/Main/MainViewController.swift
@@ -7,8 +7,6 @@
 
 import UIKit
 
-import UIKit
-
 import SnapKit
 import Then
 

--- a/Flicker/Screens/Message/Cell/MessageTableViewCell.swift
+++ b/Flicker/Screens/Message/Cell/MessageTableViewCell.swift
@@ -1,79 +1,79 @@
+////
+////  MessageTableViewCell.swift
+////  Flicker
+////
+////  Created by COBY_PRO on 2022/10/24.
+////
 //
-//  MessageTableViewCell.swift
-//  Flicker
+//import UIKit
 //
-//  Created by COBY_PRO on 2022/10/24.
+//import SnapKit
+//import Then
 //
-
-import UIKit
-
-import SnapKit
-import Then
-
-class MessageTableViewCell: BaseTableViewCell {
-    
-    // MARK: - property
-    
-    lazy var chatUserImageView = UIImageView().then {
-        let url = URL(string: "https://picsum.photos/600/600/?random")
-        $0.load(url: url!)
-        $0.layer.cornerRadius = 20
-        $0.layer.masksToBounds = true
-    }
-    
-    lazy var chatUserNameLabel = UILabel().then {
-        $0.textColor = .mainBlack
-        $0.font = UIFont.systemFont(ofSize: 15)
-        $0.font = UIFont.boldSystemFont(ofSize: UIFont.labelFontSize)
-    }
-    
-    lazy var chatDateLabel = UILabel().then {
-        $0.textColor = UIColor(hex: "#999999")
-        $0.font = UIFont.systemFont(ofSize: 11)
-    }
-    
-    lazy var chatLastLabel = UILabel().then {
-        $0.textColor = .mainBlack
-        $0.font = UIFont.systemFont(ofSize: 13)
-    }
-    
-    lazy var goodImageView = UIImageView().then {
-        let url = URL(string: "https://picsum.photos/600/600/?random")
-        $0.load(url: url!)
-        $0.layer.cornerRadius = 5
-        $0.layer.masksToBounds = true
-    }
-    
-    // MARK: - func
-    
-    override func render() {
-        contentView.addSubviews(chatUserImageView, chatUserNameLabel, chatDateLabel, chatLastLabel, goodImageView)
-        
-        chatUserImageView.snp.makeConstraints {
-            $0.width.height.equalTo(40)
-            $0.leading.equalToSuperview().inset(20)
-            $0.centerY.equalToSuperview()
-        }
-        
-        chatUserNameLabel.snp.makeConstraints {
-            $0.leading.equalTo(chatUserImageView.snp.trailing).offset(20)
-            $0.top.equalToSuperview().inset(14)
-        }
-        
-        chatDateLabel.snp.makeConstraints {
-            $0.leading.equalTo(chatUserNameLabel.snp.trailing).offset(10)
-            $0.top.equalToSuperview().inset(18)
-        }
-        
-        chatLastLabel.snp.makeConstraints {
-            $0.leading.equalTo(chatUserImageView.snp.trailing).offset(20)
-            $0.bottom.equalToSuperview().inset(14)
-        }
-        
-        goodImageView.snp.makeConstraints {
-            $0.width.height.equalTo(40)
-            $0.trailing.equalToSuperview().inset(20)
-            $0.centerY.equalToSuperview()
-        }
-    }
-}
+//class MessageTableViewCell: BaseTableViewCell {
+//    
+//    // MARK: - property
+//    
+//    lazy var chatUserImageView = UIImageView().then {
+//        let url = URL(string: "https://picsum.photos/600/600/?random")
+//        $0.load(url: url!)
+//        $0.layer.cornerRadius = 20
+//        $0.layer.masksToBounds = true
+//    }
+//    
+//    lazy var chatUserNameLabel = UILabel().then {
+//        $0.textColor = .mainBlack
+//        $0.font = UIFont.systemFont(ofSize: 15)
+//        $0.font = UIFont.boldSystemFont(ofSize: UIFont.labelFontSize)
+//    }
+//    
+//    lazy var chatDateLabel = UILabel().then {
+//        $0.textColor = UIColor(hex: "#999999")
+//        $0.font = UIFont.systemFont(ofSize: 11)
+//    }
+//    
+//    lazy var chatLastLabel = UILabel().then {
+//        $0.textColor = .mainBlack
+//        $0.font = UIFont.systemFont(ofSize: 13)
+//    }
+//    
+//    lazy var goodImageView = UIImageView().then {
+//        let url = URL(string: "https://picsum.photos/600/600/?random")
+//        $0.load(url: url!)
+//        $0.layer.cornerRadius = 5
+//        $0.layer.masksToBounds = true
+//    }
+//    
+//    // MARK: - func
+//    
+//    override func render() {
+//        contentView.addSubviews(chatUserImageView, chatUserNameLabel, chatDateLabel, chatLastLabel, goodImageView)
+//        
+//        chatUserImageView.snp.makeConstraints {
+//            $0.width.height.equalTo(40)
+//            $0.leading.equalToSuperview().inset(20)
+//            $0.centerY.equalToSuperview()
+//        }
+//        
+//        chatUserNameLabel.snp.makeConstraints {
+//            $0.leading.equalTo(chatUserImageView.snp.trailing).offset(20)
+//            $0.top.equalToSuperview().inset(14)
+//        }
+//        
+//        chatDateLabel.snp.makeConstraints {
+//            $0.leading.equalTo(chatUserNameLabel.snp.trailing).offset(10)
+//            $0.top.equalToSuperview().inset(18)
+//        }
+//        
+//        chatLastLabel.snp.makeConstraints {
+//            $0.leading.equalTo(chatUserImageView.snp.trailing).offset(20)
+//            $0.bottom.equalToSuperview().inset(14)
+//        }
+//        
+//        goodImageView.snp.makeConstraints {
+//            $0.width.height.equalTo(40)
+//            $0.trailing.equalToSuperview().inset(20)
+//            $0.centerY.equalToSuperview()
+//        }
+//    }
+//}

--- a/Flicker/Screens/Message/MessageViewController.swift
+++ b/Flicker/Screens/Message/MessageViewController.swift
@@ -1,74 +1,74 @@
+////
+////  MessageViewController.swift
+////  Flicker
+////
+////  Created by COBY_PRO on 2022/10/24.
+////
 //
-//  MessageViewController.swift
-//  Flicker
+//import UIKit
 //
-//  Created by COBY_PRO on 2022/10/24.
+//import SnapKit
+//import Then
 //
-
-import UIKit
-
-import SnapKit
-import Then
-
-final class MessageViewController: BaseViewController {
-    
-    // MARK: - property
-    
-    lazy var channelTableView = UITableView().then {
-        $0.register(MessageTableViewCell.self, forCellReuseIdentifier: MessageTableViewCell.className)
-        $0.delegate = self
-        $0.dataSource = self
-        
-        $0.separatorInset = UIEdgeInsets(top: 0, left: 0, bottom: 0, right: 0)
-    }
-    
-    var channels = [Channel]()
-    
-    // MARK: - func
-    
-    override func render() {
-        view.addSubview(channelTableView)
-        channelTableView.snp.makeConstraints {
-            $0.edges.equalToSuperview()
-        }
-        
-        channels = getChannelMocks()
-    }
-    
-    override func setupNavigationBar() {
-        super.setupNavigationBar()
-
-        navigationController?.navigationBar.prefersLargeTitles = false
-        navigationItem.largeTitleDisplayMode = .automatic
-        navigationItem.leftBarButtonItem = nil
-        
-        title = "메세지"
-    }
-}
-
-extension MessageViewController: UITableViewDataSource, UITableViewDelegate {
-    func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
-        return channels.count
-    }
-    
-    func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
-        let cell = tableView.dequeueReusableCell(withIdentifier: MessageTableViewCell.className, for: indexPath) as! MessageTableViewCell
-        
-        cell.selectionStyle = . none
-        cell.chatUserNameLabel.text = channels[indexPath.row].userName
-        cell.chatDateLabel.text = channels[indexPath.row].chatDate
-        cell.chatLastLabel.text = channels[indexPath.row].chatLast
-        return cell
-    }
-    
-    func tableView(_ tableView: UITableView, heightForRowAt indexPath: IndexPath) -> CGFloat {
-        return 70
-    }
-    
-    func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
-        let channel = channels[indexPath.row]
-        let viewController = MessageRoomViewController(channel: channel)
-        viewController.hidesBottomBarWhenPushed = true
-        navigationController?.pushViewController(viewController, animated: true)
-    }
-}
+//final class MessageViewController: BaseViewController {
+//    
+//    // MARK: - property
+//    
+//    lazy var channelTableView = UITableView().then {
+//        $0.register(MessageTableViewCell.self, forCellReuseIdentifier: MessageTableViewCell.className)
+//        $0.delegate = self
+//        $0.dataSource = self
+//        
+//        $0.separatorInset = UIEdgeInsets(top: 0, left: 0, bottom: 0, right: 0)
+//    }
+//    
+//    var channels = [Channel]()
+//    
+//    // MARK: - func
+//    
+//    override func render() {
+//        view.addSubview(channelTableView)
+//        channelTableView.snp.makeConstraints {
+//            $0.edges.equalToSuperview()
+//        }
+//        
+//        channels = getChannelMocks()
+//    }
+//    
+//    override func setupNavigationBar() {
+//        super.setupNavigationBar()
+//
+//        navigationController?.navigationBar.prefersLargeTitles = false
+//        navigationItem.largeTitleDisplayMode = .automatic
+//        navigationItem.leftBarButtonItem = nil
+//        
+//        title = "메세지"
+//    }
+//}
+//
+//extension MessageViewController: UITableViewDataSource, UITableViewDelegate {
+//    func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+//        return channels.count
+//    }
+//    
+//    func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
+//        let cell = tableView.dequeueReusableCell(withIdentifier: MessageTableViewCell.className, for: indexPath) as! MessageTableViewCell
+//        
+//        cell.selectionStyle = . none
+//        cell.chatUserNameLabel.text = channels[indexPath.row].userName
+//        cell.chatDateLabel.text = channels[indexPath.row].chatDate
+//        cell.chatLastLabel.text = channels[indexPath.row].chatLast
+//        return cell
+//    }
+//    
+//    func tableView(_ tableView: UITableView, heightForRowAt indexPath: IndexPath) -> CGFloat {
+//        return 70
+//    }
+//    
+//    func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
+//        let channel = channels[indexPath.row]
+//        let viewController = MessageRoomViewController(channel: channel)
+//        viewController.hidesBottomBarWhenPushed = true
+//        navigationController?.pushViewController(viewController, animated: true)
+//    }
+//}

--- a/Flicker/Screens/MessageRoom/MessageRoomViewController.swift
+++ b/Flicker/Screens/MessageRoom/MessageRoomViewController.swift
@@ -1,256 +1,256 @@
+////
+////  MessageRoomViewController.swift
+////  Flicker
+////
+////  Created by COBY_PRO on 2022/10/24.
+////
 //
-//  MessageRoomViewController.swift
-//  Flicker
+//import UIKit
 //
-//  Created by COBY_PRO on 2022/10/24.
+//import InputBarAccessoryView
+//import MessageKit
+//import Photos
+//import SnapKit
+//import Then
 //
-
-import UIKit
-
-import InputBarAccessoryView
-import MessageKit
-import Photos
-import SnapKit
-import Then
-
-final class MessageRoomViewController: MessagesViewController {
-    
-    // MARK: - property
-    
-    private lazy var backButton = BackButton().then {
-        $0.addTarget(self, action: #selector(didTapBackButton), for: .touchUpInside)
-    }
-    
-    private lazy var cameraBarButtonItem = InputBarButtonItem().then {
-        $0.tintColor = .mainBlack
-        $0.image = ImageLiteral.btnCamera
-        $0.addTarget(self, action: #selector(didTapCameraButton), for: .touchUpInside)
-    }
-    
-    let channel: Channel
-    var sender = Sender(senderId: "coby5502", displayName: "코비코비")
-    var messages = [Message]()
-    private var isSendingPhoto = false {
-        didSet {
-            messageInputBar.leftStackViewItems.forEach { item in
-                guard let item = item as? InputBarButtonItem else {
-                    return
-                }
-                item.isEnabled = !self.isSendingPhoto
-            }
-        }
-    }
-    
-    init(channel: Channel) {
-        self.channel = channel
-        super.init(nibName: nil, bundle: nil)
-    }
-    
-    required init?(coder: NSCoder) {
-        fatalError()
-    }
-    
-    override func viewDidLoad() {
-        super.viewDidLoad()
-        
-        setupNavigationBar()
-        setupBackButton()
-        confirmDelegates()
-        setupMessageInputBar()
-        removeOutgoingMessageAvatars()
-        addCameraBarButtonToMessageInputBar()
-    }
-    
-    private func setupNavigationBar() {
-        guard let navigationBar = navigationController?.navigationBar else { return }
-        let appearance = UINavigationBarAppearance()
-        let font = UIFont.systemFont(ofSize: 17, weight: .regular)
-        let largeFont = UIFont.systemFont(ofSize: 34, weight: .semibold)
-        
-        appearance.titleTextAttributes = [.font: font]
-        appearance.largeTitleTextAttributes = [.font: largeFont]
-        appearance.shadowColor = .clear
-        appearance.backgroundColor = .white
-        
-        navigationBar.standardAppearance = appearance
-        navigationBar.compactAppearance = appearance
-        navigationBar.scrollEdgeAppearance = appearance
-        
-        navigationController?.navigationBar.prefersLargeTitles = false
-        navigationItem.largeTitleDisplayMode = .automatic
-        
-        title = channel.userName
-    }
-    
-    // MARK: - helper func
-    
-    func makeBarButtonItem<T: UIView>(with view: T) -> UIBarButtonItem {
-        return UIBarButtonItem(customView: view)
-    }
-    
-    func removeBarButtonItemOffset(with button: UIButton, offsetX: CGFloat = 0, offsetY: CGFloat = 0) -> UIView {
-        let offsetView = UIView(frame: CGRect(x: 0, y: 0, width: 45, height: 45))
-        offsetView.bounds = offsetView.bounds.offsetBy(dx: offsetX, dy: offsetY)
-        offsetView.addSubview(button)
-        return offsetView
-    }
-    
-    // MARK: - private func
-    
-    private func setupBackButton() {
-        let leftOffsetBackButton = removeBarButtonItemOffset(with: backButton, offsetX: 10)
-        let backButton = makeBarButtonItem(with: leftOffsetBackButton)
-        
-        navigationItem.leftBarButtonItem = backButton
-    }
-    
-    @objc private func didTapBackButton() {
-        self.navigationController?.popViewController(animated: true)
-    }
-    
-    private func confirmDelegates() {
-        messagesCollectionView.messagesDataSource = self
-        messagesCollectionView.messagesLayoutDelegate = self
-        messagesCollectionView.messagesDisplayDelegate = self
-        
-        messageInputBar.delegate = self
-    }
-    
-    private func setupMessageInputBar() {
-        messageInputBar.inputTextView.tintColor = .mainYellow
-        messageInputBar.sendButton.setTitleColor(.mainYellow, for: .normal)
-        messageInputBar.inputTextView.placeholder = "채팅 입력"
-        messageInputBar.sendButton.image = ImageLiteral.btnSend
-        messageInputBar.sendButton.tintColor = .mainBlack
-        messageInputBar.sendButton.title = nil
-    }
-    
-    private func removeOutgoingMessageAvatars() {
-        guard let layout = messagesCollectionView.collectionViewLayout as? MessagesCollectionViewFlowLayout else { return }
-        layout.textMessageSizeCalculator.outgoingAvatarSize = .zero
-        layout.setMessageOutgoingAvatarSize(.zero)
-        let outgoingLabelAlignment = LabelAlignment(textAlignment: .right, textInsets: UIEdgeInsets(top: 0, left: 0, bottom: 0, right: 15))
-        layout.setMessageOutgoingMessageTopLabelAlignment(outgoingLabelAlignment)
-    }
-    
-    private func addCameraBarButtonToMessageInputBar() {
-        messageInputBar.leftStackView.alignment = .center
-        messageInputBar.setLeftStackViewWidthConstant(to: 50, animated: false)
-        messageInputBar.setStackViewItems([cameraBarButtonItem], forStack: .left, animated: false)
-    }
-    
-    private func insertNewMessage(_ message: Message) {
-        messages.append(message)
-        messages.sort()
-        
-        let isLatestMessage = messages.firstIndex(of: message) == (messages.count - 1)
-        let shouldScrollToBottom = messagesCollectionView.isAtBottom && isLatestMessage
-        
-        messagesCollectionView.reloadData()
-        
-        if shouldScrollToBottom {
-            messagesCollectionView.scrollToLastItem(animated: true)
-        }
-    }
-    
-    @objc private func didTapCameraButton() {
-        let picker = UIImagePickerController()
-        picker.delegate = self
-        
-        if UIImagePickerController.isSourceTypeAvailable(.camera) {
-            picker.sourceType = .camera
-        } else {
-            picker.sourceType = .photoLibrary
-        }
-        present(picker, animated: true)
-    }
-}
-
-extension MessageRoomViewController: MessagesDataSource {
-    var currentSender: SenderType {
-        return sender
-    }
-    
-    func numberOfSections(in messagesCollectionView: MessagesCollectionView) -> Int {
-        return messages.count
-    }
-    
-    func messageForItem(at indexPath: IndexPath, in messagesCollectionView: MessagesCollectionView) -> MessageType {
-        return messages[indexPath.section]
-    }
-    
-    func messageTopLabelAttributedText(for message: MessageType, at indexPath: IndexPath) -> NSAttributedString? {
-        let name = message.sender.displayName
-        return NSAttributedString(string: name, attributes: [.font: UIFont.preferredFont(forTextStyle: .caption1),
-                                                             .foregroundColor: UIColor(white: 0.3, alpha: 1)])
-    }
-}
-
-extension MessageRoomViewController: MessagesLayoutDelegate {
-    // 아래 여백
-    func footerViewSize(for section: Int, in messagesCollectionView: MessagesCollectionView) -> CGSize {
-        return CGSize(width: 0, height: 8)
-    }
-    
-    // 말풍선 위 이름 나오는 곳의 height
-    func messageTopLabelHeight(for message: MessageType, at indexPath: IndexPath, in messagesCollectionView: MessagesCollectionView) -> CGFloat {
-        return 20
-    }
-}
-
-// 상대방이 보낸 메시지, 내가 보낸 메시지를 구분하여 색상과 모양 지정
-extension MessageRoomViewController: MessagesDisplayDelegate {
-    // 말풍선의 배경 색상
-    func backgroundColor(for message: MessageType, at indexPath: IndexPath, in messagesCollectionView: MessagesCollectionView) -> UIColor {
-        return isFromCurrentSender(message: message) ? .mainYellow : .mainBlack
-    }
-    
-    func textColor(for message: MessageType, at indexPath: IndexPath, in messagesCollectionView: MessagesCollectionView) -> UIColor {
-        return isFromCurrentSender(message: message) ? .black : .white
-    }
-    
-    // 말풍선의 꼬리 모양 방향
-    func messageStyle(for message: MessageType, at indexPath: IndexPath, in messagesCollectionView: MessagesCollectionView) -> MessageStyle {
-        let cornerDirection: MessageStyle.TailCorner = isFromCurrentSender(message: message) ? .bottomRight : .bottomLeft
-        return .bubbleTail(cornerDirection, .curved)
-    }
-}
-
-extension MessageRoomViewController: InputBarAccessoryViewDelegate {
-    func inputBar(_ inputBar: InputBarAccessoryView, didPressSendButtonWith text: String) {
-        let message = Message(content: text)
-        insertNewMessage(message)
-        inputBar.inputTextView.text.removeAll()
-    }
-}
-
-extension MessageRoomViewController: UIImagePickerControllerDelegate, UINavigationControllerDelegate {
-    func imagePickerController(_ picker: UIImagePickerController, didFinishPickingMediaWithInfo info: [UIImagePickerController.InfoKey : Any]) {
-        picker.dismiss(animated: true)
-        
-        if let asset = info[.phAsset] as? PHAsset {
-            let imageSize = CGSize(width: 500, height: 500)
-            PHImageManager.default().requestImage(for: asset,
-                                                  targetSize: imageSize,
-                                                  contentMode: .aspectFit,
-                                                  options: nil) { image, _ in
-                guard let image = image else { return }
-                self.sendPhoto(image)
-            }
-        } else if let image = info[.originalImage] as? UIImage {
-            sendPhoto(image)
-        }
-    }
-    
-    private func sendPhoto(_ image: UIImage) {
-        isSendingPhoto = true
-        // TODO: upload to firebase
-        isSendingPhoto = false
-        let message = Message(image: image)
-        insertNewMessage(message)
-    }
-    
-    func imagePickerControllerDidCancel(_ picker: UIImagePickerController) {
-        picker.dismiss(animated: true)
-    }
-}
+//final class MessageRoomViewController: MessagesViewController {
+//    
+//    // MARK: - property
+//    
+//    private lazy var backButton = BackButton().then {
+//        $0.addTarget(self, action: #selector(didTapBackButton), for: .touchUpInside)
+//    }
+//    
+//    private lazy var cameraBarButtonItem = InputBarButtonItem().then {
+//        $0.tintColor = .mainBlack
+//        $0.image = ImageLiteral.btnCamera
+//        $0.addTarget(self, action: #selector(didTapCameraButton), for: .touchUpInside)
+//    }
+//    
+//    let channel: Channel
+//    var sender = Sender(senderId: "coby5502", displayName: "코비코비")
+//    var messages = [Message]()
+//    private var isSendingPhoto = false {
+//        didSet {
+//            messageInputBar.leftStackViewItems.forEach { item in
+//                guard let item = item as? InputBarButtonItem else {
+//                    return
+//                }
+//                item.isEnabled = !self.isSendingPhoto
+//            }
+//        }
+//    }
+//    
+//    init(channel: Channel) {
+//        self.channel = channel
+//        super.init(nibName: nil, bundle: nil)
+//    }
+//    
+//    required init?(coder: NSCoder) {
+//        fatalError()
+//    }
+//    
+//    override func viewDidLoad() {
+//        super.viewDidLoad()
+//        
+//        setupNavigationBar()
+//        setupBackButton()
+//        confirmDelegates()
+//        setupMessageInputBar()
+//        removeOutgoingMessageAvatars()
+//        addCameraBarButtonToMessageInputBar()
+//    }
+//    
+//    private func setupNavigationBar() {
+//        guard let navigationBar = navigationController?.navigationBar else { return }
+//        let appearance = UINavigationBarAppearance()
+//        let font = UIFont.systemFont(ofSize: 17, weight: .regular)
+//        let largeFont = UIFont.systemFont(ofSize: 34, weight: .semibold)
+//        
+//        appearance.titleTextAttributes = [.font: font]
+//        appearance.largeTitleTextAttributes = [.font: largeFont]
+//        appearance.shadowColor = .clear
+//        appearance.backgroundColor = .white
+//        
+//        navigationBar.standardAppearance = appearance
+//        navigationBar.compactAppearance = appearance
+//        navigationBar.scrollEdgeAppearance = appearance
+//        
+//        navigationController?.navigationBar.prefersLargeTitles = false
+//        navigationItem.largeTitleDisplayMode = .automatic
+//        
+//        title = channel.userName
+//    }
+//    
+//    // MARK: - helper func
+//    
+//    func makeBarButtonItem<T: UIView>(with view: T) -> UIBarButtonItem {
+//        return UIBarButtonItem(customView: view)
+//    }
+//    
+//    func removeBarButtonItemOffset(with button: UIButton, offsetX: CGFloat = 0, offsetY: CGFloat = 0) -> UIView {
+//        let offsetView = UIView(frame: CGRect(x: 0, y: 0, width: 45, height: 45))
+//        offsetView.bounds = offsetView.bounds.offsetBy(dx: offsetX, dy: offsetY)
+//        offsetView.addSubview(button)
+//        return offsetView
+//    }
+//    
+//    // MARK: - private func
+//    
+//    private func setupBackButton() {
+//        let leftOffsetBackButton = removeBarButtonItemOffset(with: backButton, offsetX: 10)
+//        let backButton = makeBarButtonItem(with: leftOffsetBackButton)
+//        
+//        navigationItem.leftBarButtonItem = backButton
+//    }
+//    
+//    @objc private func didTapBackButton() {
+//        self.navigationController?.popViewController(animated: true)
+//    }
+//    
+//    private func confirmDelegates() {
+//        messagesCollectionView.messagesDataSource = self
+//        messagesCollectionView.messagesLayoutDelegate = self
+//        messagesCollectionView.messagesDisplayDelegate = self
+//        
+//        messageInputBar.delegate = self
+//    }
+//    
+//    private func setupMessageInputBar() {
+//        messageInputBar.inputTextView.tintColor = .mainYellow
+//        messageInputBar.sendButton.setTitleColor(.mainYellow, for: .normal)
+//        messageInputBar.inputTextView.placeholder = "채팅 입력"
+//        messageInputBar.sendButton.image = ImageLiteral.btnSend
+//        messageInputBar.sendButton.tintColor = .mainBlack
+//        messageInputBar.sendButton.title = nil
+//    }
+//    
+//    private func removeOutgoingMessageAvatars() {
+//        guard let layout = messagesCollectionView.collectionViewLayout as? MessagesCollectionViewFlowLayout else { return }
+//        layout.textMessageSizeCalculator.outgoingAvatarSize = .zero
+//        layout.setMessageOutgoingAvatarSize(.zero)
+//        let outgoingLabelAlignment = LabelAlignment(textAlignment: .right, textInsets: UIEdgeInsets(top: 0, left: 0, bottom: 0, right: 15))
+//        layout.setMessageOutgoingMessageTopLabelAlignment(outgoingLabelAlignment)
+//    }
+//    
+//    private func addCameraBarButtonToMessageInputBar() {
+//        messageInputBar.leftStackView.alignment = .center
+//        messageInputBar.setLeftStackViewWidthConstant(to: 50, animated: false)
+//        messageInputBar.setStackViewItems([cameraBarButtonItem], forStack: .left, animated: false)
+//    }
+//    
+//    private func insertNewMessage(_ message: Message) {
+//        messages.append(message)
+//        messages.sort()
+//        
+//        let isLatestMessage = messages.firstIndex(of: message) == (messages.count - 1)
+//        let shouldScrollToBottom = messagesCollectionView.isAtBottom && isLatestMessage
+//        
+//        messagesCollectionView.reloadData()
+//        
+//        if shouldScrollToBottom {
+//            messagesCollectionView.scrollToLastItem(animated: true)
+//        }
+//    }
+//    
+//    @objc private func didTapCameraButton() {
+//        let picker = UIImagePickerController()
+//        picker.delegate = self
+//        
+//        if UIImagePickerController.isSourceTypeAvailable(.camera) {
+//            picker.sourceType = .camera
+//        } else {
+//            picker.sourceType = .photoLibrary
+//        }
+//        present(picker, animated: true)
+//    }
+//}
+//
+//extension MessageRoomViewController: MessagesDataSource {
+//    var currentSender: SenderType {
+//        return sender
+//    }
+//    
+//    func numberOfSections(in messagesCollectionView: MessagesCollectionView) -> Int {
+//        return messages.count
+//    }
+//    
+//    func messageForItem(at indexPath: IndexPath, in messagesCollectionView: MessagesCollectionView) -> MessageType {
+//        return messages[indexPath.section]
+//    }
+//    
+//    func messageTopLabelAttributedText(for message: MessageType, at indexPath: IndexPath) -> NSAttributedString? {
+//        let name = message.sender.displayName
+//        return NSAttributedString(string: name, attributes: [.font: UIFont.preferredFont(forTextStyle: .caption1),
+//                                                             .foregroundColor: UIColor(white: 0.3, alpha: 1)])
+//    }
+//}
+//
+//extension MessageRoomViewController: MessagesLayoutDelegate {
+//    // 아래 여백
+//    func footerViewSize(for section: Int, in messagesCollectionView: MessagesCollectionView) -> CGSize {
+//        return CGSize(width: 0, height: 8)
+//    }
+//    
+//    // 말풍선 위 이름 나오는 곳의 height
+//    func messageTopLabelHeight(for message: MessageType, at indexPath: IndexPath, in messagesCollectionView: MessagesCollectionView) -> CGFloat {
+//        return 20
+//    }
+//}
+//
+//// 상대방이 보낸 메시지, 내가 보낸 메시지를 구분하여 색상과 모양 지정
+//extension MessageRoomViewController: MessagesDisplayDelegate {
+//    // 말풍선의 배경 색상
+//    func backgroundColor(for message: MessageType, at indexPath: IndexPath, in messagesCollectionView: MessagesCollectionView) -> UIColor {
+//        return isFromCurrentSender(message: message) ? .mainYellow : .mainBlack
+//    }
+//    
+//    func textColor(for message: MessageType, at indexPath: IndexPath, in messagesCollectionView: MessagesCollectionView) -> UIColor {
+//        return isFromCurrentSender(message: message) ? .black : .white
+//    }
+//    
+//    // 말풍선의 꼬리 모양 방향
+//    func messageStyle(for message: MessageType, at indexPath: IndexPath, in messagesCollectionView: MessagesCollectionView) -> MessageStyle {
+//        let cornerDirection: MessageStyle.TailCorner = isFromCurrentSender(message: message) ? .bottomRight : .bottomLeft
+//        return .bubbleTail(cornerDirection, .curved)
+//    }
+//}
+//
+//extension MessageRoomViewController: InputBarAccessoryViewDelegate {
+//    func inputBar(_ inputBar: InputBarAccessoryView, didPressSendButtonWith text: String) {
+//        let message = Message(content: text)
+//        insertNewMessage(message)
+//        inputBar.inputTextView.text.removeAll()
+//    }
+//}
+//
+//extension MessageRoomViewController: UIImagePickerControllerDelegate, UINavigationControllerDelegate {
+//    func imagePickerController(_ picker: UIImagePickerController, didFinishPickingMediaWithInfo info: [UIImagePickerController.InfoKey : Any]) {
+//        picker.dismiss(animated: true)
+//        
+//        if let asset = info[.phAsset] as? PHAsset {
+//            let imageSize = CGSize(width: 500, height: 500)
+//            PHImageManager.default().requestImage(for: asset,
+//                                                  targetSize: imageSize,
+//                                                  contentMode: .aspectFit,
+//                                                  options: nil) { image, _ in
+//                guard let image = image else { return }
+//                self.sendPhoto(image)
+//            }
+//        } else if let image = info[.originalImage] as? UIImage {
+//            sendPhoto(image)
+//        }
+//    }
+//    
+//    private func sendPhoto(_ image: UIImage) {
+//        isSendingPhoto = true
+//        // TODO: upload to firebase
+//        isSendingPhoto = false
+//        let message = Message(image: image)
+//        insertNewMessage(message)
+//    }
+//    
+//    func imagePickerControllerDidCancel(_ picker: UIImagePickerController) {
+//        picker.dismiss(animated: true)
+//    }
+//}

--- a/Flicker/Screens/Profile/ProfileViewController.swift
+++ b/Flicker/Screens/Profile/ProfileViewController.swift
@@ -6,6 +6,7 @@
 //
 
 import UIKit
+import AuthenticationServices
 
 import SnapKit
 import Then
@@ -13,7 +14,14 @@ import Then
 final class ProfileViewController: BaseViewController {
 
     // MARK: - property
+    private let signOutButton = UIButton().then {
+          $0.backgroundColor = .mainBlack
+          $0.setTitleColor(.white, for: .normal)
+          $0.setTitle("Sign Out", for: .normal)
+        $0.addTarget(self, action: #selector(signOutButtonPress), for: .touchUpInside)
+      }
 
+    
     private let screenText = UILabel().then {
         $0.textColor = .red
         $0.text = "프로필"
@@ -21,8 +29,28 @@ final class ProfileViewController: BaseViewController {
     
     override func render() {
         view.addSubview(screenText)
+        view.addSubview(signOutButton)
+
         screenText.snp.makeConstraints {
             $0.centerX.centerY.equalToSuperview()
         }
+
+        signOutButton.snp.makeConstraints {
+            $0.top.equalTo(screenText.snp.bottom).offset(20)
+            $0.leading.trailing.equalToSuperview().inset(20)
+            $0.height.equalTo(60)
+        }
+    }
+}
+
+extension ProfileViewController {
+
+    @objc private func signOutButtonPress() {
+        
+        KeychainItem.deleteUserIdentifierFromKeychain()
+        print("workOut")
+//        DispatchQueue.main.async {
+//            self.LogInViewController()
+//        }
     }
 }

--- a/Flicker/Screens/Tabbar/TabbarViewController.swift
+++ b/Flicker/Screens/Tabbar/TabbarViewController.swift
@@ -11,7 +11,7 @@ final class TabbarViewController: UITabBarController {
     
     private let mainViewController = UINavigationController(rootViewController: MainViewController())
     private let searchViewController = UINavigationController(rootViewController: SearchViewController())
-    private let messageViewController = UINavigationController(rootViewController: MessageViewController())
+//    private let messageViewController = UINavigationController(rootViewController: MessageViewController())
     private let profileViewController = UINavigationController(rootViewController: ProfileViewController())
     
     override func viewDidLoad() {
@@ -23,14 +23,14 @@ final class TabbarViewController: UITabBarController {
         searchViewController.tabBarItem.image = ImageLiteral.btnSearch
         searchViewController.tabBarItem.title = "검색"
         
-        messageViewController.tabBarItem.image = ImageLiteral.btnMessage
-        messageViewController.tabBarItem.title = "메세지"
+//        messageViewController.tabBarItem.image = ImageLiteral.btnMessage
+//        messageViewController.tabBarItem.title = "메세지"
         
         profileViewController.tabBarItem.image = ImageLiteral.btnProfile
         profileViewController.tabBarItem.title = "프로필"
         
         tabBar.tintColor = .mainYellow
         tabBar.backgroundColor = .white
-        setViewControllers([mainViewController, searchViewController, messageViewController, profileViewController], animated: true)
+        setViewControllers([mainViewController, searchViewController, /*messageViewController*/ profileViewController], animated: true)
     }
 }


### PR DESCRIPTION
## 배경
- 애플아이디를 사용한 로그인을 앱의 주 로그인으로 사용하기 위해 기초적인 로그인을 구현했습니다.

- 코비가 MessageKit을 삭제 후 나중에 추가하신다고 하셔서 관련 부분 모두 주석처리 및 패키지를 삭제진행하였습니다.

- 다른 분들이 작업 전에 루키가 작업한 코드와 이번 PR을 합한 후 시작하기 위함입니다.
## 작업 내용 (Content)
- KeyChainItem값을 통해 로그인여부를 파악하는 로직입니다.
- 파이어베이스와 연동을 위해 파이어베이스에서 애플 로그인을 연동한 부분을 찾아 수정해야하며, 이미 로그인 한 사람일 경우 바로 홈 화면으로 넘어가도록 로직을 좀 더 수정해야합니다.

## 스크린샷
- 화면 전환이나 인터렉션이 있는 경우엔 GIF, 정적인 화면이라면 스크린샷을 이용합니다.

<p align="left">
  <img width="300" alt="스크린샷1" src="https://user-images.githubusercontent.com/81131715/198932675-01407300-3671-485e-8ca2-5e176c03c051.gif">
</p>


## 테스트방법
- 로그인 버튼을 누르면 애플로그인이 되고 원래는 설정에 있는 SignOut버튼을 누르면 저장된 키체인 값이 삭제되며 다시 로그인을 해야하지만 추가작업이 필요합니다.

## PR & Issues
- #3

## 참고문서, 레퍼런스
- https://developer.apple.com/documentation/authenticationservices/implementing_user_authentication_with_sign_in_with_apple
