### PR TITLE
Merge시 pbxfile 충돌방지를 위해 gitattribute를 추가합니다.

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.pbxproj binary merge=union


### PR DESCRIPTION
## pbxproj 파일, workspace파일
<img width="500" alt="image" src="https://user-images.githubusercontent.com/103009135/199158148-6c265854-dc9e-4ad6-91f9-6f806aea73e0.png">

Xcode 파일을 분해해서 보면 pbxproj파일과 workspace파일이 있습니다.

#### workspace는 프로젝트 및 기타 문서를 그룹화하여 함께 작업할 수 있는 Xcode document입니다. 
한마디로 한개의 프로젝트가 아닌 여러개의 프로젝트를 한군데 모아 작업하고 싶으면 workspace를 만들어서 관리해야합니다. 예를 들어cocoapods 등을 사용하여 외부 라이브러리 등을 내 프로젝트에 추가한 경우에 xcworkspace에서 내 프로젝트와 외부 라이브러리를 연결해주는 연할을 하게됩니다. (외부 라이브러리 추가가 없는 경우 pbxproj 파일만 있습니다.)

#### pbxproj 파일은 Build Setting(실제 프로젝트의 설정) 을 담은 파일입니다.
프로젝트 내부에서 생성된 파일들을 파일 유형에 따라 reference를 저장하고 있습니다. 이 project.pbxproj는 사실 git을 사용할 경우 충돌이 일어나는 주요 파일 중 하나입니다. 

2명의 팀원이 작업을 위해 각자 A 파일, B 파일을 생성하여 각자 커밋한 경우 한 쪽에는 B 파일의 reference, 다른 쪽은 A 파일의 reference가 없습니다. 그래서 두 작업에서 사용된 project.pbxproj 파일은 서로 다른 reference를 가지고 있어서 conflict가 일어납니다. 그리고 이 충돌이 고치기 쉽지 않은 것이 project.pbxproj가 깨지면 프로젝트 자체가 열리지 않습니다. 그러므로 이럴 때는 에디터나 소스트리 같은 형상 관리 툴로 해당 충돌을 수정해야 합니다. (아마 많이들 겪으셨을거라고 생각합니다,,,)

## Git Attribute
#### Git attribute를 통해 Merge는 어떻게 할지, 텍스트가 아닌 파일은 어떻게 수정 사항들을 비교할지 등을 설정할 수 있습니다.
Git은 우리가 머지 할 때 텍스트 파일을 비교해서 수정사항의 충돌여부를 판별하게 됩니다. 하지만 pbxfile은 워낙에 알아들을 수 없는 텍스트로 구성되어있어 개발자들이 건드리기가 쉽지않습니다. 

그래서 이런 파일들은 그냥 바이너리 파일로 취급해버리고 merge할 때 그냥 합치게하는 옵션을 git attibute에 적용하면 됩니다. 
#### *.pbxproj binary merge=union

## 작업 내용 (Content)
그냥 이거 한줄 추가한게 다입니다.
9f51bdd7cc852c51e1808e50fafc206ca49324e2 

## Notes
cozy 말로는 파일이 추가될 때 충돌을 없애는 코드라 만일 파일이 삭제될경우 충돌이 발생할 수도 있다고 하네요?

## 테스트방법
머지할 때 한번 봅시다 ㅋㅎㅋ

## 참고문서, 레퍼런스
[pbxfile](https://hcn1519.github.io/articles/2018-06/xcodeconfiguration)
[workspace](https://jeongupark-study-house.tistory.com/160)
[pbxfile 컨플릭 방지 방법](https://velog.io/@honghoker/git-Xcode-pbxproj-merge-conflict-문제-해결-방법)