### PR TITLE
💄 MainView UI 구현

### DIFF
--- a/Flicker.xcodeproj/project.pbxproj
+++ b/Flicker.xcodeproj/project.pbxproj
@@ -26,6 +26,7 @@
 		A9F1F2E8290CC5690018C73F /* HeaderCollectionReusableView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9F1F2E7290CC5690018C73F /* HeaderCollectionReusableView.swift */; };
 		CB33C1D1290621C200F37626 /* GoogleService-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = CB33C1D0290621C200F37626 /* GoogleService-Info.plist */; };
 		CB5A8C322913534200AECE98 /* RegionListHorizontalView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB5A8C312913534200AECE98 /* RegionListHorizontalView.swift */; };
+		CB5A8C342913688B00AECE98 /* ArtistThumnailCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB5A8C332913688B00AECE98 /* ArtistThumnailCollectionViewCell.swift */; };
 		CB5B1C3029134F75001E1EBD /* Then in Frameworks */ = {isa = PBXBuildFile; productRef = CB5B1C2F29134F75001E1EBD /* Then */; };
 		CBDC03D429060E6600C6CF30 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = CBDC03D329060E6600C6CF30 /* AppDelegate.swift */; };
 		CBDC03D629060E6600C6CF30 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = CBDC03D529060E6600C6CF30 /* SceneDelegate.swift */; };
@@ -82,6 +83,7 @@
 		CB33C1CF2906214200F37626 /* Flicker.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = Flicker.entitlements; sourceTree = "<group>"; };
 		CB33C1D0290621C200F37626 /* GoogleService-Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = "GoogleService-Info.plist"; sourceTree = "<group>"; };
 		CB5A8C312913534200AECE98 /* RegionListHorizontalView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RegionListHorizontalView.swift; sourceTree = "<group>"; };
+		CB5A8C332913688B00AECE98 /* ArtistThumnailCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ArtistThumnailCollectionViewCell.swift; sourceTree = "<group>"; };
 		CBDC03D029060E6600C6CF30 /* Flicker.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Flicker.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		CBDC03D329060E6600C6CF30 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		CBDC03D529060E6600C6CF30 /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
@@ -424,6 +426,7 @@
 			isa = PBXGroup;
 			children = (
 				CBFBC05E2913434400FBBD17 /* RegionCollectionViewCell.swift */,
+				CB5A8C332913688B00AECE98 /* ArtistThumnailCollectionViewCell.swift */,
 			);
 			path = Cell;
 			sourceTree = "<group>";
@@ -533,6 +536,7 @@
 				CBDC04092906102F00C6CF30 /* UIView+Extension.swift in Sources */,
 				CBDC04262906122200C6CF30 /* Mocks.swift in Sources */,
 				A94957FC290E3DF500B74693 /* AccessKey.swift in Sources */,
+				CB5A8C342913688B00AECE98 /* ArtistThumnailCollectionViewCell.swift in Sources */,
 				CBDC03D829060E6600C6CF30 /* MainViewController.swift in Sources */,
 				CBDC03F129060F0800C6CF30 /* ImageLiteral.swift in Sources */,
 				CBDC03FF29060FBC00C6CF30 /* UIColor+Extension.swift in Sources */,

--- a/Flicker.xcodeproj/project.pbxproj
+++ b/Flicker.xcodeproj/project.pbxproj
@@ -16,7 +16,6 @@
 		10FE6B6829064FE60064201F /* FirebaseStorage in Frameworks */ = {isa = PBXBuildFile; productRef = 10FE6B6729064FE60064201F /* FirebaseStorage */; };
 		10FE6B6B290651150064201F /* Lottie in Frameworks */ = {isa = PBXBuildFile; productRef = 10FE6B6A290651150064201F /* Lottie */; };
 		10FE6B6E290651630064201F /* SnapKit in Frameworks */ = {isa = PBXBuildFile; productRef = 10FE6B6D290651630064201F /* SnapKit */; };
-		10FE6B712906519E0064201F /* Then in Frameworks */ = {isa = PBXBuildFile; productRef = 10FE6B702906519E0064201F /* Then */; };
 		7B3DC41829114B5900646909 /* AccountDeleteViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B3DC41729114B5900646909 /* AccountDeleteViewController.swift */; };
 		A94957F6290E3A4900B74693 /* NetworkErrorCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = A94957F5290E3A4900B74693 /* NetworkErrorCase.swift */; };
 		A94957F8290E3A6000B74693 /* APIResponseDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = A94957F7290E3A6000B74693 /* APIResponseDTO.swift */; };
@@ -26,6 +25,8 @@
 		A9F1F2E6290CC0EE0018C73F /* ArtistPortfolioCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9F1F2E5290CC0EE0018C73F /* ArtistPortfolioCell.swift */; };
 		A9F1F2E8290CC5690018C73F /* HeaderCollectionReusableView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9F1F2E7290CC5690018C73F /* HeaderCollectionReusableView.swift */; };
 		CB33C1D1290621C200F37626 /* GoogleService-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = CB33C1D0290621C200F37626 /* GoogleService-Info.plist */; };
+		CB5A8C322913534200AECE98 /* RegionListHorizontalView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB5A8C312913534200AECE98 /* RegionListHorizontalView.swift */; };
+		CB5B1C3029134F75001E1EBD /* Then in Frameworks */ = {isa = PBXBuildFile; productRef = CB5B1C2F29134F75001E1EBD /* Then */; };
 		CBDC03D429060E6600C6CF30 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = CBDC03D329060E6600C6CF30 /* AppDelegate.swift */; };
 		CBDC03D629060E6600C6CF30 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = CBDC03D529060E6600C6CF30 /* SceneDelegate.swift */; };
 		CBDC03D829060E6600C6CF30 /* MainViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = CBDC03D729060E6600C6CF30 /* MainViewController.swift */; };
@@ -64,13 +65,13 @@
 		CBDC043A2906143200C6CF30 /* TabbarViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = CBDC04392906143200C6CF30 /* TabbarViewController.swift */; };
 		CBDC043D290614C100C6CF30 /* SearchViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = CBDC043C290614C100C6CF30 /* SearchViewController.swift */; };
 		CBDC04402906151600C6CF30 /* ProfileViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = CBDC043F2906151600C6CF30 /* ProfileViewController.swift */; };
+		CBFBC05F2913434400FBBD17 /* RegionCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = CBFBC05E2913434400FBBD17 /* RegionCollectionViewCell.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
-		1066BFE629097BB2000B8555 /* KeychainItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeychainItem.swift; sourceTree = "<group>"; };
-		7B3DC41729114B5900646909 /* AccountDeleteViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccountDeleteViewController.swift; sourceTree = "<group>"; };
 		1032FFA42910C03D00AE3363 /* TsukimiRounded-Bold.ttf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "TsukimiRounded-Bold.ttf"; sourceTree = "<group>"; };
 		1032FFA62911EE6400AE3363 /* ProfileSettingViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfileSettingViewController.swift; sourceTree = "<group>"; };
+		7B3DC41729114B5900646909 /* AccountDeleteViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccountDeleteViewController.swift; sourceTree = "<group>"; };
 		A94957F5290E3A4900B74693 /* NetworkErrorCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkErrorCase.swift; sourceTree = "<group>"; };
 		A94957F7290E3A6000B74693 /* APIResponseDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APIResponseDTO.swift; sourceTree = "<group>"; };
 		A94957F9290E3A8300B74693 /* NetworkManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkManager.swift; sourceTree = "<group>"; };
@@ -80,6 +81,7 @@
 		A9F1F2E7290CC5690018C73F /* HeaderCollectionReusableView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HeaderCollectionReusableView.swift; sourceTree = "<group>"; };
 		CB33C1CF2906214200F37626 /* Flicker.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = Flicker.entitlements; sourceTree = "<group>"; };
 		CB33C1D0290621C200F37626 /* GoogleService-Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = "GoogleService-Info.plist"; sourceTree = "<group>"; };
+		CB5A8C312913534200AECE98 /* RegionListHorizontalView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RegionListHorizontalView.swift; sourceTree = "<group>"; };
 		CBDC03D029060E6600C6CF30 /* Flicker.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Flicker.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		CBDC03D329060E6600C6CF30 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		CBDC03D529060E6600C6CF30 /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
@@ -120,6 +122,7 @@
 		CBDC04392906143200C6CF30 /* TabbarViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabbarViewController.swift; sourceTree = "<group>"; };
 		CBDC043C290614C100C6CF30 /* SearchViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchViewController.swift; sourceTree = "<group>"; };
 		CBDC043F2906151600C6CF30 /* ProfileViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfileViewController.swift; sourceTree = "<group>"; };
+		CBFBC05E2913434400FBBD17 /* RegionCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RegionCollectionViewCell.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -130,7 +133,7 @@
 				10FE6B6629064FE60064201F /* FirebaseMessaging in Frameworks */,
 				10FE6B6829064FE60064201F /* FirebaseStorage in Frameworks */,
 				10FE6B6029064FE60064201F /* FirebaseAuth in Frameworks */,
-				10FE6B712906519E0064201F /* Then in Frameworks */,
+				CB5B1C3029134F75001E1EBD /* Then in Frameworks */,
 				10FE6B6E290651630064201F /* SnapKit in Frameworks */,
 				10FE6B6429064FE60064201F /* FirebaseFirestoreSwift in Frameworks */,
 				10FE6B6229064FE60064201F /* FirebaseFirestore in Frameworks */,
@@ -162,11 +165,19 @@
 			path = Artist;
 			sourceTree = "<group>";
 		};
+		CB5B1C2E29134F75001E1EBD /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+			);
+			name = Frameworks;
+			sourceTree = "<group>";
+		};
 		CBDC03C729060E6600C6CF30 = {
 			isa = PBXGroup;
 			children = (
 				CBDC03D229060E6600C6CF30 /* Flicker */,
 				CBDC03D129060E6600C6CF30 /* Products */,
+				CB5B1C2E29134F75001E1EBD /* Frameworks */,
 			);
 			sourceTree = "<group>";
 		};
@@ -344,6 +355,8 @@
 		CBDC042D2906126B00C6CF30 /* Main */ = {
 			isa = PBXGroup;
 			children = (
+				CBFBC05C2913431A00FBBD17 /* UIComponent */,
+				CBFBC05D2913432100FBBD17 /* Cell */,
 				CBDC03D729060E6600C6CF30 /* MainViewController.swift */,
 			);
 			path = Main;
@@ -399,6 +412,22 @@
 			path = Profile;
 			sourceTree = "<group>";
 		};
+		CBFBC05C2913431A00FBBD17 /* UIComponent */ = {
+			isa = PBXGroup;
+			children = (
+				CB5A8C312913534200AECE98 /* RegionListHorizontalView.swift */,
+			);
+			path = UIComponent;
+			sourceTree = "<group>";
+		};
+		CBFBC05D2913432100FBBD17 /* Cell */ = {
+			isa = PBXGroup;
+			children = (
+				CBFBC05E2913434400FBBD17 /* RegionCollectionViewCell.swift */,
+			);
+			path = Cell;
+			sourceTree = "<group>";
+		};
 /* End PBXGroup section */
 
 /* Begin PBXNativeTarget section */
@@ -423,7 +452,7 @@
 				10FE6B6729064FE60064201F /* FirebaseStorage */,
 				10FE6B6A290651150064201F /* Lottie */,
 				10FE6B6D290651630064201F /* SnapKit */,
-				10FE6B702906519E0064201F /* Then */,
+				CB5B1C2F29134F75001E1EBD /* Then */,
 			);
 			productName = Flicker;
 			productReference = CBDC03D029060E6600C6CF30 /* Flicker.app */;
@@ -509,12 +538,14 @@
 				CBDC03FF29060FBC00C6CF30 /* UIColor+Extension.swift in Sources */,
 				A94957F6290E3A4900B74693 /* NetworkErrorCase.swift in Sources */,
 				CBDC043D290614C100C6CF30 /* SearchViewController.swift in Sources */,
+				CB5A8C322913534200AECE98 /* RegionListHorizontalView.swift in Sources */,
 				CBDC04072906102000C6CF30 /* NSObject+Extension.swift in Sources */,
 				CBDC042A2906124600C6CF30 /* SignUpViewController.swift in Sources */,
 				A9F1F2E4290CB99A0018C73F /* ArtistTappedViewController.swift in Sources */,
 				CBDC040D2906106500C6CF30 /* Notification+Extension.swift in Sources */,
 				A94957FA290E3A8300B74693 /* NetworkManager.swift in Sources */,
 				CBDC042C2906125A00C6CF30 /* LoginViewController.swift in Sources */,
+				CBFBC05F2913434400FBBD17 /* RegionCollectionViewCell.swift in Sources */,
 				CBDC03FD29060F7A00C6CF30 /* PushNotificationSender.swift in Sources */,
 				CBDC03FB29060F6E00C6CF30 /* FirebaseManager.swift in Sources */,
 				CBDC03D429060E6600C6CF30 /* AppDelegate.swift in Sources */,
@@ -831,7 +862,7 @@
 			package = 10FE6B6C290651620064201F /* XCRemoteSwiftPackageReference "SnapKit" */;
 			productName = SnapKit;
 		};
-		10FE6B702906519E0064201F /* Then */ = {
+		CB5B1C2F29134F75001E1EBD /* Then */ = {
 			isa = XCSwiftPackageProductDependency;
 			package = 10FE6B6F2906519E0064201F /* XCRemoteSwiftPackageReference "Then" */;
 			productName = Then;

--- a/Flicker/Screens/Main/Cell/ArtistThumnailCollectionViewCell.swift
+++ b/Flicker/Screens/Main/Cell/ArtistThumnailCollectionViewCell.swift
@@ -1,0 +1,38 @@
+//
+//  ArtistThumnailCollectionViewCell.swift
+//  Flicker
+//
+//  Created by COBY_PRO on 2022/11/03.
+//
+
+import UIKit
+
+import SnapKit
+import Then
+
+final class ArtistThumnailCollectionViewCell: BaseCollectionViewCell {
+    
+    // MARK: - property
+    
+    let artistNameLabel = UILabel().then {
+        $0.font = .preferredFont(forTextStyle: .body, weight: .bold)
+        $0.textColor = .white
+        $0.textAlignment = .center
+    }
+    
+    override func render() {
+        contentView.addSubview(artistNameLabel)
+        
+        artistNameLabel.snp.makeConstraints {
+            $0.top.equalToSuperview().inset(200)
+            $0.leading.equalToSuperview().inset(30)
+        }
+    }
+    
+    override func configUI() {
+        clipsToBounds = true
+        backgroundColor = .black
+        layer.masksToBounds = false
+        layer.cornerRadius = 20
+    }
+}

--- a/Flicker/Screens/Main/Cell/ArtistThumnailCollectionViewCell.swift
+++ b/Flicker/Screens/Main/Cell/ArtistThumnailCollectionViewCell.swift
@@ -21,20 +21,21 @@ final class ArtistThumnailCollectionViewCell: BaseCollectionViewCell {
     }
     
     let artistNameLabel = UILabel().then {
-        $0.font = UIFont.systemFont(ofSize: 22, weight: .regular)
+        $0.font = UIFont.preferredFont(forTextStyle: .title2, weight: .bold)
+        
         $0.textColor = .white
         $0.textAlignment = .center
     }
     
     private let artistLabel = UILabel().then {
-        $0.font = UIFont.systemFont(ofSize: 17, weight: .regular)
+        $0.font = UIFont.preferredFont(forTextStyle: .body, weight: .bold)
         $0.textColor = .white
         $0.textAlignment = .center
         $0.text = "작가님"
     }
     
     let artistInfoLabel = UILabel().then {
-        $0.font = UIFont.systemFont(ofSize: 15, weight: .regular)
+        $0.font = UIFont.preferredFont(forTextStyle: .subheadline, weight: .bold)
         $0.textColor = .white
         $0.numberOfLines = 2
     }

--- a/Flicker/Screens/Main/Cell/ArtistThumnailCollectionViewCell.swift
+++ b/Flicker/Screens/Main/Cell/ArtistThumnailCollectionViewCell.swift
@@ -14,25 +14,62 @@ final class ArtistThumnailCollectionViewCell: BaseCollectionViewCell {
     
     // MARK: - property
     
+    lazy var artistThumnailImageView = UIImageView().then {
+        $0.clipsToBounds = true
+        $0.contentMode = .scaleAspectFill
+        $0.layer.cornerRadius = 20
+    }
+    
     let artistNameLabel = UILabel().then {
-        $0.font = .preferredFont(forTextStyle: .body, weight: .bold)
+        $0.font = UIFont.systemFont(ofSize: 22, weight: .regular)
         $0.textColor = .white
         $0.textAlignment = .center
     }
     
+    private let artistLabel = UILabel().then {
+        $0.font = UIFont.systemFont(ofSize: 17, weight: .regular)
+        $0.textColor = .white
+        $0.textAlignment = .center
+        $0.text = "작가님"
+    }
+    
+    let artistInfoLabel = UILabel().then {
+        $0.font = UIFont.systemFont(ofSize: 15, weight: .regular)
+        $0.textColor = .white
+        $0.numberOfLines = 2
+    }
+    
+    lazy var artistProfileImageView = UIImageView().then {
+        $0.layer.cornerRadius = 30
+        $0.layer.masksToBounds = true
+    }
+    
     override func render() {
-        contentView.addSubview(artistNameLabel)
+        contentView.addSubviews(artistNameLabel, artistLabel, artistInfoLabel, artistProfileImageView)
         
         artistNameLabel.snp.makeConstraints {
             $0.top.equalToSuperview().inset(200)
             $0.leading.equalToSuperview().inset(30)
         }
+        
+        artistLabel.snp.makeConstraints {
+            $0.bottom.equalTo(artistNameLabel.snp.bottom).offset(-2)
+            $0.leading.equalTo(artistNameLabel.snp.trailing).offset(8)
+        }
+        
+        artistInfoLabel.snp.makeConstraints {
+            $0.leading.equalToSuperview().inset(30)
+            $0.top.equalTo(artistLabel.snp.bottom).offset(10)
+            $0.width.lessThanOrEqualTo(220)
+        }
+        
+        artistProfileImageView.snp.makeConstraints {
+            $0.trailing.bottom.equalToSuperview().inset(30)
+            $0.width.height.equalTo(60)
+        }
     }
     
     override func configUI() {
-        clipsToBounds = true
-        backgroundColor = .black
-        layer.masksToBounds = false
-        layer.cornerRadius = 20
+        backgroundView = artistThumnailImageView
     }
 }

--- a/Flicker/Screens/Main/Cell/RegionCollectionViewCell.swift
+++ b/Flicker/Screens/Main/Cell/RegionCollectionViewCell.swift
@@ -15,7 +15,7 @@ final class RegionCollectionViewCell: BaseCollectionViewCell {
     // MARK: - property
     
     let regionLabel = UILabel().then {
-        $0.font = UIFont.systemFont(ofSize: 15, weight: .bold)
+        $0.font = UIFont.preferredFont(forTextStyle: .subheadline, weight: .bold)
         $0.textAlignment = .center
     }
     

--- a/Flicker/Screens/Main/Cell/RegionCollectionViewCell.swift
+++ b/Flicker/Screens/Main/Cell/RegionCollectionViewCell.swift
@@ -1,0 +1,48 @@
+//
+//  RegionCollectionViewCell.swift
+//  Flicker
+//
+//  Created by COBY_PRO on 2022/11/03.
+//
+
+import UIKit
+
+import SnapKit
+import Then
+
+final class RegionCollectionViewCell: BaseCollectionViewCell {
+    
+    // MARK: - property
+    
+    let regionLabel = UILabel().then {
+        $0.font = UIFont.systemFont(ofSize: 15, weight: .bold)
+        $0.textAlignment = .center
+    }
+    
+    override func render() {
+        contentView.addSubview(regionLabel)
+        
+        regionLabel.snp.makeConstraints {
+            $0.centerX.equalToSuperview()
+            $0.bottom.equalToSuperview().inset(10)
+        }
+    }
+    
+    override func configUI() {
+        clipsToBounds = true
+        contentView.layer.cornerRadius = 15
+        contentView.backgroundColor = .black.withAlphaComponent(0.15)
+    }
+    
+    override var isSelected: Bool {
+        didSet {
+            if isSelected {
+                contentView.backgroundColor = .black
+                self.regionLabel.textColor = .white
+            } else {
+                contentView.backgroundColor = .black.withAlphaComponent(0.15)
+                self.regionLabel.textColor = .black
+            }
+        }
+    }
+}

--- a/Flicker/Screens/Main/MainViewController.swift
+++ b/Flicker/Screens/Main/MainViewController.swift
@@ -11,18 +11,42 @@ import SnapKit
 import Then
 
 final class MainViewController: BaseViewController {
+    
+    private var region: String = "전체"
 
     // MARK: - property
     
-    private let screenText = UILabel().then {
-        $0.textColor = .red
-        $0.text = "홈"
+    private let appTitleLabel = UILabel().then {
+        $0.font = UIFont(name: "TsukimiRounded-Bold", size: 30)
+        $0.textColor = .mainPink
+        $0.textAlignment = .center
+        $0.text = "SHUGGLE"
+    }
+    
+    private let regionListHorizontalView = RegionListHorizontalView()
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        
+        regionListHorizontalView.setParentViewController(viewController: self)
     }
     
     override func render() {
-        view.addSubview(screenText)
-        screenText.snp.makeConstraints {
-            $0.centerX.centerY.equalToSuperview()
+        view.addSubviews(appTitleLabel, regionListHorizontalView)
+        
+        appTitleLabel.snp.makeConstraints {
+            $0.top.equalTo(view.safeAreaLayoutGuide)
+            $0.leading.equalToSuperview().inset(20)
         }
+        
+        regionListHorizontalView.snp.makeConstraints {
+            $0.top.equalTo(appTitleLabel.snp.bottom).offset(20)
+            $0.leading.trailing.equalToSuperview()
+            $0.height.equalTo(60)
+        }
+    }
+    
+    func setRegion(region: String) {
+        self.region = region
     }
 }

--- a/Flicker/Screens/Main/MainViewController.swift
+++ b/Flicker/Screens/Main/MainViewController.swift
@@ -12,6 +12,17 @@ import Then
 
 final class MainViewController: BaseViewController {
     
+    private enum Size {
+        static let collectionHorizontalSpacing: CGFloat = 20.0
+        static let collectionVerticalSpacing: CGFloat = 20.0
+        static let cellWidth: CGFloat = UIScreen.main.bounds.size.width - collectionHorizontalSpacing * 2
+        static let cellHeight: CGFloat = 300
+        static let collectionInset = UIEdgeInsets(top: collectionVerticalSpacing,
+                                                  left: collectionHorizontalSpacing,
+                                                  bottom: collectionVerticalSpacing,
+                                                  right: collectionHorizontalSpacing)
+    }
+    
     private var region: String = "전체"
 
     // MARK: - property
@@ -25,6 +36,22 @@ final class MainViewController: BaseViewController {
     
     private let regionListHorizontalView = RegionListHorizontalView()
     
+    private let collectionViewFlowLayout = UICollectionViewFlowLayout().then {
+        $0.scrollDirection = .vertical
+        $0.sectionInset = Size.collectionInset
+        $0.itemSize = CGSize(width: Size.cellWidth, height: Size.cellHeight)
+        $0.minimumLineSpacing = 24
+    }
+    
+    private lazy var listCollectionView = UICollectionView(frame: .zero, collectionViewLayout: collectionViewFlowLayout).then {
+        $0.backgroundColor = .clear
+        $0.dataSource = self
+        $0.delegate = self
+        $0.showsVerticalScrollIndicator = false
+        $0.register(ArtistThumnailCollectionViewCell.self,
+                                forCellWithReuseIdentifier: ArtistThumnailCollectionViewCell.className)
+    }
+    
     override func viewDidLoad() {
         super.viewDidLoad()
         
@@ -32,7 +59,7 @@ final class MainViewController: BaseViewController {
     }
     
     override func render() {
-        view.addSubviews(appTitleLabel, regionListHorizontalView)
+        view.addSubviews(appTitleLabel, regionListHorizontalView, listCollectionView)
         
         appTitleLabel.snp.makeConstraints {
             $0.top.equalTo(view.safeAreaLayoutGuide)
@@ -42,11 +69,37 @@ final class MainViewController: BaseViewController {
         regionListHorizontalView.snp.makeConstraints {
             $0.top.equalTo(appTitleLabel.snp.bottom).offset(20)
             $0.leading.trailing.equalToSuperview()
-            $0.height.equalTo(60)
+            $0.height.equalTo(80)
+        }
+        
+        listCollectionView.snp.makeConstraints {
+            $0.top.equalTo(regionListHorizontalView.snp.bottom)
+            $0.leading.trailing.bottom.equalToSuperview()
         }
     }
     
     func setRegion(region: String) {
         self.region = region
+    }
+}
+
+// MARK: - UICollectionViewDataSource
+extension MainViewController: UICollectionViewDataSource {
+    func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
+        return 10
+    }
+    
+    func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
+        guard let cell = collectionView.dequeueReusableCell(withReuseIdentifier: ArtistThumnailCollectionViewCell.className, for: indexPath) as? ArtistThumnailCollectionViewCell else {
+            assert(false, "Wrong Cell")
+        }
+        return cell
+    }
+}
+
+// MARK: - UICollectionViewDelegate
+extension MainViewController: UICollectionViewDelegate {
+    func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
+        // 터치시 넘어가는 화면 코드 구현 예정
     }
 }

--- a/Flicker/Screens/Main/MainViewController.swift
+++ b/Flicker/Screens/Main/MainViewController.swift
@@ -93,6 +93,12 @@ extension MainViewController: UICollectionViewDataSource {
         guard let cell = collectionView.dequeueReusableCell(withReuseIdentifier: ArtistThumnailCollectionViewCell.className, for: indexPath) as? ArtistThumnailCollectionViewCell else {
             assert(false, "Wrong Cell")
         }
+        
+        cell.artistNameLabel.text = "킹도영"
+        cell.artistInfoLabel.text = "울트라캡숑짱짱맨울트라캡숑짱짱맨울트라캡숑짱짱맨울트라캡숑짱짱맨"
+        cell.artistThumnailImageView.image = UIImage(named: "port1")
+        cell.artistProfileImageView.image = UIImage(named: "port2")
+        
         return cell
     }
 }

--- a/Flicker/Screens/Main/UIComponent/RegionListHorizontalView.swift
+++ b/Flicker/Screens/Main/UIComponent/RegionListHorizontalView.swift
@@ -82,7 +82,6 @@ extension RegionListHorizontalView: UICollectionViewDataSource {
         
         if indexPath.item == 0 {
             cell.isSelected = true
-            collectionView.selectItem(at: indexPath, animated: false , scrollPosition: .init())
         }
         
         cell.regionLabel.text = reigionList[indexPath.item]
@@ -94,7 +93,6 @@ extension RegionListHorizontalView: UICollectionViewDataSource {
 // MARK: - UICollectionViewDelegate
 extension RegionListHorizontalView: UICollectionViewDelegateFlowLayout {
     func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
-        collectionView.scrollToItem(at: indexPath, at: .centeredHorizontally, animated: true)
         parent?.setRegion(region: reigionList[indexPath.item])
     }
 }

--- a/Flicker/Screens/Main/UIComponent/RegionListHorizontalView.swift
+++ b/Flicker/Screens/Main/UIComponent/RegionListHorizontalView.swift
@@ -1,0 +1,100 @@
+//
+//  RegionListHorizontalView.swift
+//  Flicker
+//
+//  Created by COBY_PRO on 2022/11/03.
+//
+
+import UIKit
+
+import SnapKit
+import Then
+
+final class RegionListHorizontalView: UIView {
+
+    private let reigionList = ["전체", "서울", "부산", "포항", "동해", "삼척", "강릉", "춘천", "속초"]
+    
+    private var parent: MainViewController?
+    
+    private enum Size {
+        static let collectionHorizontalSpacing: CGFloat = 20.0
+        static let collectionVerticalSpacing: CGFloat = 0.0
+        static let cellWidth: CGFloat = 60
+        static let cellHeight: CGFloat = 60
+        static let collectionInset = UIEdgeInsets(top: collectionVerticalSpacing,
+                                                  left: collectionHorizontalSpacing,
+                                                  bottom: collectionVerticalSpacing,
+                                                  right: collectionHorizontalSpacing)
+    }
+    
+    // MARK: - property
+    
+    private let collectionViewFlowLayout = UICollectionViewFlowLayout().then {
+        $0.scrollDirection = .horizontal
+        $0.sectionInset = Size.collectionInset
+        $0.itemSize = CGSize(width: Size.cellWidth, height: Size.cellHeight)
+        $0.minimumLineSpacing = 6
+    }
+    
+    private lazy var listCollectionView = UICollectionView(frame: .zero, collectionViewLayout: collectionViewFlowLayout).then {
+        $0.backgroundColor = .clear
+        $0.dataSource = self
+        $0.delegate = self
+        $0.showsHorizontalScrollIndicator = false
+        $0.register(RegionCollectionViewCell.self,
+                                forCellWithReuseIdentifier: RegionCollectionViewCell.className)
+    }
+    
+    // MARK: - init
+    
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        render()
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    private func render() {
+        self.addSubview(listCollectionView)
+        
+        listCollectionView.snp.makeConstraints {
+            $0.edges.equalToSuperview()
+        }
+    }
+    
+    func setParentViewController(viewController: MainViewController) {
+        self.parent = viewController
+    }
+}
+
+// MARK: - UICollectionViewDataSource
+extension RegionListHorizontalView: UICollectionViewDataSource {
+    func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
+        return reigionList.count
+    }
+    
+    func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
+        guard let cell = collectionView.dequeueReusableCell(withReuseIdentifier: RegionCollectionViewCell.className, for: indexPath) as? RegionCollectionViewCell else {
+            assert(false, "Wrong Cell")
+        }
+        
+        if indexPath.item == 0 {
+            cell.isSelected = true
+            collectionView.selectItem(at: indexPath, animated: false , scrollPosition: .init())
+        }
+        
+        cell.regionLabel.text = reigionList[indexPath.item]
+    
+        return cell
+    }
+}
+
+// MARK: - UICollectionViewDelegate
+extension RegionListHorizontalView: UICollectionViewDelegateFlowLayout {
+    func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
+        collectionView.scrollToItem(at: indexPath, at: .centeredHorizontally, animated: true)
+        parent?.setRegion(region: reigionList[indexPath.item])
+    }
+}

--- a/Flicker/Screens/Tabbar/TabbarViewController.swift
+++ b/Flicker/Screens/Tabbar/TabbarViewController.swift
@@ -9,7 +9,7 @@ import UIKit
 
 final class TabbarViewController: UITabBarController {
     
-    private let mainViewController = UINavigationController(rootViewController: ArtistTappedViewController())
+    private let mainViewController = UINavigationController(rootViewController: MainViewController())
     private let searchViewController = UINavigationController(rootViewController: SearchViewController())
 //    private let messageViewController = UINavigationController(rootViewController: MessageViewController())
     private let profileViewController = UINavigationController(rootViewController: ProfileViewController())


### PR DESCRIPTION
## 배경
- 메인 화면을 구현하였습니다.

## 작업 내용 (Content)
- [x] 지역 태그 리스트 ColletionView로 구현
- [x] 지역 태그 Cell UI
- [x] 작가 썸네일 리스트 ColletionView로 구현
- [x] 작가 썸네일 Cell UI

- 데이터를 불러오는 코드 없이, 간단한 UI만 구성하였습니다.
- 지역 태그를 선택했을 때, 어떤 태그를 클릭했는지 정도까지만 코드를 구현하였습니다.

## 스크린샷

<p align="left">
  <img width="200" alt="스크린샷1" src="https://user-images.githubusercontent.com/57849386/199654600-e508fa88-73d3-4992-b2e8-cacf207aed30.png">
</p>


## 테스트방법
- 해당 브랜치에서 빌드하시면 됩니다. 

## 추가 전달사항
- 작가 썸네일에서, 사진 배경에 따라, 글자 스타일이 변경되거나 다른 디자인을 해야할 것 같습니다.
- 배경이 밝으면, 기존의 하얀색 폰트가 잘 보이지 않습니다.
- 마찬가지로, 작가 썸네일 안의, 작가 프로필이미지도 인스타그램처럼 테두리라도 넣을까 싶습니다.

## PR & Issues
- #16

## 참고문서, 레퍼런스
- 작업을 하면서 참고한 문서 및 레퍼런스를 작성합니다.
