### PR TITLE
:sparkles: 로그인 실패 시 얼럿을 통한 확인 및 뷰가 로드 될 때 키보드가 뜨는 이슈 제거했습니다.

### DIFF
--- a/Flicker/Screens/Login/LoginViewController.swift
+++ b/Flicker/Screens/Login/LoginViewController.swift
@@ -201,7 +201,6 @@ final class LogInViewController: BaseViewController {
     
     override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
-        emailField.becomeFirstResponder()
     }
     
     private func goHome() {
@@ -254,6 +253,7 @@ final class LogInViewController: BaseViewController {
     @objc private func didTapLogInbutton() {
         guard let email = emailField.text, !email.isEmpty,
               let password = passwordField.text, !password.isEmpty else {
+            makeAlert(title: "아이디 또는 비밀번호가 일치하지 않습니다.", message: "")
             print("Missing field data")
             return
         }
@@ -265,6 +265,7 @@ final class LogInViewController: BaseViewController {
             await FirebaseManager.shared.updateUserToken(uid: userId)
             self?.goHome()
         }
+        makeAlert(title: "아이디 또는 비밀번호가 일치하지 않습니다.", message: "")
     }
 
     @objc private func didTapSignUpButton() {


### PR DESCRIPTION
## 🌁 배경
- 로그인 화면이 로드될 때 바로 EmailTextField로 가도록 되어있어 키보드가 뜨는 현상이 있어 이는 UX적으로 맞지 않다고 생각해 이를 제거하는 작업이 필요했습니다.

- 처음 테스크는 로그인시 이메일에 대한 유효성 검사를 하는 것 이였습니다. 하지만 이 화면은 회원가입 화면이 아닌, 로그인을 화는 화면이라 제 판단에는 유효성 검사가 아닌 입력을 한번 더 확인하라는 얼럿이 더 UX에 맞다고 생각이 들어 테스크와는 다르게 구현을 했습니다.

- 이 뷰에는 오히려 비밀번호 찾기 기능이 추가되어야 한다고 생각이 듭니다..

## 👩‍💻 작업 내용 (Content)
- 뷰가 로드되자마자 이메일 텍스트 필드로 클릭이 가는 코드를 제거했습니다.

- 이메일 텍스트필드, 패스워드 텍스트 필드가 비어 있거나, 로그인에 실패 했을때 얼럿을 통해 확인을 시켜주는 기능을 구현했습니다.

## 📱 스크린샷
- 화면 전환이나 인터렉션이 있는 경우엔 GIF, 정적인 화면이라면 스크린샷을 이용합니다.

<p align="center">
  <img width="300" alt="스크린샷1" src="https://user-images.githubusercontent.com/81131715/201276665-b289f3d2-91f1-40cc-815f-472f9689bbe1.gif">
</p>


## ✅ 테스트방법
- PR리뷰어가 변경사항을 확인할 수 있는 방법을 서술합니다.

## 📣 PR & Issues
- 현재 작성 중인 Pull Request와 관련된 PR과 Issues가 있다면 나열합니다.
- closed #41 

## 📬 참고문서, 레퍼런스
- 작업을 하면서 참고한 문서 및 레퍼런스를 작성합니다.

