### PR TITLE
CardView에 네비게이션 기능을 넣었습니다

### DIFF
--- a/Flicker/Screens/Profile/ProfileHeaderVIew.swift
+++ b/Flicker/Screens/Profile/ProfileHeaderVIew.swift
@@ -39,7 +39,7 @@ final class ProfileHeaderVIew: UIView {
     }
     
     private lazy var emailLabel = UILabel().then {
-        $0.text = userEmail ?? "User Email Error. please report this issue to us"
+        $0.text = userEmail ?? "User Email Error"
         $0.font = .preferredFont(forTextStyle: .footnote, weight: .regular)
         $0.textColor = .textSubBlack
     }

--- a/Flicker/Screens/Profile/ProfileViewController.swift
+++ b/Flicker/Screens/Profile/ProfileViewController.swift
@@ -24,18 +24,13 @@ final class ProfileViewController: BaseViewController {
 
     override func viewDidLoad() {
         super.viewDidLoad()
-        render()
         setFunctionsAndDelegate()
-        customSetUI()
+        render()
+        setTabGesture()
     }
     // MARK: - rendering Functions
     override func viewWillAppear(_ animated: Bool) {
         navigationController?.setNavigationBarHidden(false, animated: true)
-    }
-    
-    private func customSetUI() {
-        view.addSubviews(tableView, profileHeader)
-        tableView.tableHeaderView = profileHeader
     }
 
     override func render() {
@@ -57,14 +52,20 @@ final class ProfileViewController: BaseViewController {
         tableView.delegate = self
         tableView.dataSource = self
     }
-    
+    private func setTabGesture() {
+        let tabGesture = UITapGestureRecognizer(target: self, action: #selector(didTapGesture))
+        self.profileHeader.addGestureRecognizer(tabGesture)
+    }
     // MARK: - Setting Functions
+    @objc func didTapGesture() {
+        print("asdf")
+        navigationController?
+            .pushViewController(LoginProfileViewController(), animated: true)
+    }
     @objc func didToggleSwitch(_ sender: UISwitch) {
         print(sender.isOn)
         if !sender.isOn {
             makeAlert(title: "알림 비활성화", message: "")
-        } else {
-            
         }
     }
     private func goToArtistRegistration() {


### PR DESCRIPTION
추가로 필요없는 코드를 삭제하여 조금 더 클-린 해졌습니다.

## 🌁 배경
- 하디의 요청으로 기능을 테스트하기 위하여 네비게이션을 붙였습니다. 진작에 신경 썼어야 했는데 귀찮게 해서 죄송합니다!

## 👩‍💻 작업 내용 (Content)
- 기존에 급하게 만들다보니 겹치는 코드가 있는데 인식하지 못 하고 있던걸 인식하여 지웠습니다.
- 프로필 화면에서 카드를 탭하면 네비게이션으로 프로필을 수정하거나 탈퇴 혹은 로그인 할 수 있는 화면으로 이동합니다. 여기에 인자값을 주어 화면 변경되는 것을 생각해보았으나 로그인 화면 구성을 어떻게 하는지 잘 몰라 일단은 그냥 PR 올립니다!

## ✅ 테스트방법
- 프로필 화면에서 카드를 탭하시면 됩니다.
