### PR TITLE
🎨💄✨🐛 로그인, 로그아웃 플로우를 조져놨습니다.

### DIFF
--- a/Flicker.xcodeproj/project.pbxproj
+++ b/Flicker.xcodeproj/project.pbxproj
@@ -223,6 +223,14 @@
 			path = InputPassword;
 			sourceTree = "<group>";
 		};
+		1085610F2923EA6D0083E156 /* ProfileSetting */ = {
+			isa = PBXGroup;
+			children = (
+				108561102923EAB00083E156 /* ProfileSettingViewController.swift */,
+			);
+			path = ProfileSetting;
+			sourceTree = "<group>";
+		};
 		58118D372911328A00F08D35 /* ArtistRegister */ = {
 			isa = PBXGroup;
 			children = (
@@ -510,6 +518,7 @@
 				CB3314E82923311400E11D70 /* Region */,
 				CBDC043B2906149000C6CF30 /* Search */,
 				CBDC043E290614FD00C6CF30 /* Profile */,
+				1085610F2923EA6D0083E156 /* ProfileSetting */,
 			);
 			path = Screens;
 			sourceTree = "<group>";
@@ -685,6 +694,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				CBDC040B2906104800C6CF30 /* UILabel+Extension.swift in Sources */,
+				108561112923EAB00083E156 /* ProfileSettingViewController.swift in Sources */,
 				A94957F8290E3A6000B74693 /* APIResponseDTO.swift in Sources */,
 				1032FFA72911EE6400AE3363 /* LoginProfileViewController.swift in Sources */,
 				CBDC040F2906107900C6CF30 /* UIFont+Extension.swift in Sources */,

--- a/Flicker.xcodeproj/project.pbxproj
+++ b/Flicker.xcodeproj/project.pbxproj
@@ -226,9 +226,18 @@
 		1085610F2923EA6D0083E156 /* ProfileSetting */ = {
 			isa = PBXGroup;
 			children = (
+				108561142924FBD10083E156 /* InputPassword */,
 				108561102923EAB00083E156 /* ProfileSettingViewController.swift */,
 			);
 			path = ProfileSetting;
+			sourceTree = "<group>";
+		};
+		108561142924FBD10083E156 /* InputPassword */ = {
+			isa = PBXGroup;
+			children = (
+				108561152924FBFD0083E156 /* InputPasswordViewController.swift */,
+			);
+			path = InputPassword;
 			sourceTree = "<group>";
 		};
 		58118D372911328A00F08D35 /* ArtistRegister */ = {

--- a/Flicker.xcodeproj/project.pbxproj
+++ b/Flicker.xcodeproj/project.pbxproj
@@ -206,7 +206,7 @@
 			path = WithDraw;
 				103EB1FB29224F2600E11A2A /* SignOutViewController.swift */,
 			);
-			path = SignOut;
+			path = WithDraw;
 			sourceTree = "<group>";
 		};
 		103EB1FA29224EDE00E11A2A /* LogOut */ = {

--- a/Flicker.xcodeproj/project.pbxproj
+++ b/Flicker.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		102A4BEB29253AB2005A8BE5 /* AppleLoginManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 102A4BEA29253AB2005A8BE5 /* AppleLoginManager.swift */; };
 		1032FFA52910C03D00AE3363 /* TsukimiRounded-Bold.ttf in Resources */ = {isa = PBXBuildFile; fileRef = 1032FFA42910C03D00AE3363 /* TsukimiRounded-Bold.ttf */; };
 		1032FFA72911EE6400AE3363 /* LoginProfileViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1032FFA62911EE6400AE3363 /* LoginProfileViewController.swift */; };
 		103EB1FC29224F2600E11A2A /* WithDrawViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 103EB1FB29224F2600E11A2A /* WithDrawViewController.swift */; };
@@ -96,6 +97,7 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
+		102A4BEA29253AB2005A8BE5 /* AppleLoginManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppleLoginManager.swift; sourceTree = "<group>"; };
 		1032FFA42910C03D00AE3363 /* TsukimiRounded-Bold.ttf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "TsukimiRounded-Bold.ttf"; sourceTree = "<group>"; };
 		1032FFA62911EE6400AE3363 /* LoginProfileViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginProfileViewController.swift; sourceTree = "<group>"; };
 		103EB1FB29224F2600E11A2A /* WithDrawViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WithDrawViewController.swift; sourceTree = "<group>"; };
@@ -204,23 +206,6 @@
 				103EB1FB29224F2600E11A2A /* WithDrawViewController.swift */,
 			);
 			path = WithDraw;
-			sourceTree = "<group>";
-		};
-		1085610F2923EA6D0083E156 /* ProfileSetting */ = {
-			isa = PBXGroup;
-			children = (
-				108561142924FBD10083E156 /* InputPassword */,
-				108561102923EAB00083E156 /* ProfileSettingViewController.swift */,
-			);
-			path = ProfileSetting;
-			sourceTree = "<group>";
-		};
-		108561142924FBD10083E156 /* InputPassword */ = {
-			isa = PBXGroup;
-			children = (
-				108561152924FBFD0083E156 /* InputPasswordViewController.swift */,
-			);
-			path = InputPassword;
 			sourceTree = "<group>";
 		};
 		1085610F2923EA6D0083E156 /* ProfileSetting */ = {
@@ -459,6 +444,7 @@
 				CBDC03F829060F6400C6CF30 /* Logger.swift */,
 				CBDC03FA29060F6E00C6CF30 /* FirebaseManager.swift */,
 				CBDC03FC29060F7A00C6CF30 /* PushNotificationSender.swift */,
+				102A4BEA29253AB2005A8BE5 /* AppleLoginManager.swift */,
 			);
 			path = Utils;
 			sourceTree = "<group>";
@@ -728,6 +714,7 @@
 				CB26EFD3292385F100B9B137 /* RegionTagView.swift in Sources */,
 				CB5A8C342913688B00AECE98 /* ArtistThumnailCollectionViewCell.swift in Sources */,
 				CBDC03D829060E6600C6CF30 /* MainViewController.swift in Sources */,
+				102A4BEB29253AB2005A8BE5 /* AppleLoginManager.swift in Sources */,
 				7B3DC43D2914DA8C00646909 /* ProfileEnumeration.swift in Sources */,
 				CB3314EB292339AC00E11D70 /* RegionViewController.swift in Sources */,
 				108561162924FBFD0083E156 /* InputPasswordViewController.swift in Sources */,

--- a/Flicker.xcodeproj/project.pbxproj
+++ b/Flicker.xcodeproj/project.pbxproj
@@ -209,13 +209,6 @@
 			path = WithDraw;
 			sourceTree = "<group>";
 		};
-		103EB1FA29224EDE00E11A2A /* LogOut */ = {
-			isa = PBXGroup;
-			children = (
-			);
-			path = LogOut;
-			sourceTree = "<group>";
-		};
 		1085610F2923EA6D0083E156 /* ProfileSetting */ = {
 			isa = PBXGroup;
 			children = (

--- a/Flicker.xcodeproj/project.pbxproj
+++ b/Flicker.xcodeproj/project.pbxproj
@@ -9,6 +9,9 @@
 /* Begin PBXBuildFile section */
 		1032FFA52910C03D00AE3363 /* TsukimiRounded-Bold.ttf in Resources */ = {isa = PBXBuildFile; fileRef = 1032FFA42910C03D00AE3363 /* TsukimiRounded-Bold.ttf */; };
 		1032FFA72911EE6400AE3363 /* LoginProfileViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1032FFA62911EE6400AE3363 /* LoginProfileViewController.swift */; };
+		103EB1FC29224F2600E11A2A /* WithDrawViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 103EB1FB29224F2600E11A2A /* WithDrawViewController.swift */; };
+		108561112923EAB00083E156 /* ProfileSettingViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 108561102923EAB00083E156 /* ProfileSettingViewController.swift */; };
+		108561162924FBFD0083E156 /* InputPasswordViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 108561152924FBFD0083E156 /* InputPasswordViewController.swift */; };
 		10FE6B6029064FE60064201F /* FirebaseAuth in Frameworks */ = {isa = PBXBuildFile; productRef = 10FE6B5F29064FE60064201F /* FirebaseAuth */; };
 		10FE6B6229064FE60064201F /* FirebaseFirestore in Frameworks */ = {isa = PBXBuildFile; productRef = 10FE6B6129064FE60064201F /* FirebaseFirestore */; };
 		10FE6B6429064FE60064201F /* FirebaseFirestoreSwift in Frameworks */ = {isa = PBXBuildFile; productRef = 10FE6B6329064FE60064201F /* FirebaseFirestoreSwift */; };
@@ -95,6 +98,9 @@
 /* Begin PBXFileReference section */
 		1032FFA42910C03D00AE3363 /* TsukimiRounded-Bold.ttf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "TsukimiRounded-Bold.ttf"; sourceTree = "<group>"; };
 		1032FFA62911EE6400AE3363 /* LoginProfileViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginProfileViewController.swift; sourceTree = "<group>"; };
+		103EB1FB29224F2600E11A2A /* WithDrawViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WithDrawViewController.swift; sourceTree = "<group>"; };
+		108561102923EAB00083E156 /* ProfileSettingViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfileSettingViewController.swift; sourceTree = "<group>"; };
+		108561152924FBFD0083E156 /* InputPasswordViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InputPasswordViewController.swift; sourceTree = "<group>"; };
 		58118D38291132FB00F08D35 /* ArtistRegisterViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ArtistRegisterViewController.swift; sourceTree = "<group>"; };
 		58118D4C29116B5400F08D35 /* RegisterRegionTagCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RegisterRegionTagCell.swift; sourceTree = "<group>"; };
 		58118D4E29116B8B00F08D35 /* LeftAlignedCollectionViewFlowLayout.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LeftAlignedCollectionViewFlowLayout.swift; sourceTree = "<group>"; };
@@ -198,23 +204,23 @@
 				103EB1FB29224F2600E11A2A /* WithDrawViewController.swift */,
 			);
 			path = WithDraw;
-		103EB1F929224EC300E11A2A /* SignOut */ = {
-			isa = PBXGroup;
-			children = (
-				103EB1FB29224F2600E11A2A /* WithDrawViewController.swift */,
-			);
-			path = WithDraw;
-				103EB1FB29224F2600E11A2A /* SignOutViewController.swift */,
-			);
-			path = WithDraw;
 			sourceTree = "<group>";
 		};
 		1085610F2923EA6D0083E156 /* ProfileSetting */ = {
 			isa = PBXGroup;
 			children = (
+				108561142924FBD10083E156 /* InputPassword */,
 				108561102923EAB00083E156 /* ProfileSettingViewController.swift */,
 			);
 			path = ProfileSetting;
+			sourceTree = "<group>";
+		};
+		108561142924FBD10083E156 /* InputPassword */ = {
+			isa = PBXGroup;
+			children = (
+				108561152924FBFD0083E156 /* InputPasswordViewController.swift */,
+			);
+			path = InputPassword;
 			sourceTree = "<group>";
 		};
 		58118D372911328A00F08D35 /* ArtistRegister */ = {
@@ -499,6 +505,7 @@
 				CBDC04382906142600C6CF30 /* Tabbar */,
 				CBDC04282906123700C6CF30 /* Login */,
 				CBDC04272906123100C6CF30 /* SignUp */,
+				103EB1F929224EC300E11A2A /* WithDraw */,
 				CBDC042D2906126B00C6CF30 /* Main */,
 				CB3314E82923311400E11D70 /* Region */,
 				CBDC043B2906149000C6CF30 /* Search */,
@@ -688,6 +695,7 @@
 				CBDC040129060FD600C6CF30 /* UIViewController+Extension.swift in Sources */,
 				CB3314E729232C7B00E11D70 /* AppTitleView.swift in Sources */,
 				CBDC0411290610A200C6CF30 /* UITextView+Extension.swift in Sources */,
+				103EB1FC29224F2600E11A2A /* WithDrawViewController.swift in Sources */,
 				CBDC0413290610AD00C6CF30 /* Sequence+Extension.swift in Sources */,
 				CBDC03F329060F2500C6CF30 /* BaseViewController.swift in Sources */,
 				CBB0ACF62923A21C00B3381F /* StateTagListView.swift in Sources */,
@@ -703,6 +711,7 @@
 				CBDC03D829060E6600C6CF30 /* MainViewController.swift in Sources */,
 				7B3DC43D2914DA8C00646909 /* ProfileEnumeration.swift in Sources */,
 				CB3314EB292339AC00E11D70 /* RegionViewController.swift in Sources */,
+				108561162924FBFD0083E156 /* InputPasswordViewController.swift in Sources */,
 				CBDC03F129060F0800C6CF30 /* ImageLiteral.swift in Sources */,
 				CBDC03FF29060FBC00C6CF30 /* UIColor+Extension.swift in Sources */,
 				A94957F6290E3A4900B74693 /* NetworkErrorCase.swift in Sources */,

--- a/Flicker.xcodeproj/project.pbxproj
+++ b/Flicker.xcodeproj/project.pbxproj
@@ -192,6 +192,38 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		103EB1F929224EC300E11A2A /* WithDraw */ = {
+			isa = PBXGroup;
+			children = (
+				103EB1FB29224F2600E11A2A /* WithDrawViewController.swift */,
+			);
+			path = WithDraw;
+		103EB1F929224EC300E11A2A /* SignOut */ = {
+			isa = PBXGroup;
+			children = (
+				103EB1FB29224F2600E11A2A /* WithDrawViewController.swift */,
+			);
+			path = WithDraw;
+				103EB1FB29224F2600E11A2A /* SignOutViewController.swift */,
+			);
+			path = SignOut;
+			sourceTree = "<group>";
+		};
+		103EB1FA29224EDE00E11A2A /* LogOut */ = {
+			isa = PBXGroup;
+			children = (
+			);
+			path = LogOut;
+			sourceTree = "<group>";
+		};
+		1085610F2923EA6D0083E156 /* ProfileSetting */ = {
+			isa = PBXGroup;
+			children = (
+				108561102923EAB00083E156 /* ProfileSettingViewController.swift */,
+			);
+			path = ProfileSetting;
+			sourceTree = "<group>";
+		};
 		58118D372911328A00F08D35 /* ArtistRegister */ = {
 			isa = PBXGroup;
 			children = (

--- a/Flicker/Global/Base/BaseViewController.swift
+++ b/Flicker/Global/Base/BaseViewController.swift
@@ -146,21 +146,6 @@ extension BaseViewController: UIGestureRecognizerDelegate {
 
 extension BaseViewController {
 
-    func reAuthUser() {
-        let user = Auth.auth().currentUser
-        var credential: AuthCredential
-
-        // Prompt the user to re-provide their sign-in credentials
-//
-//        user?.reauthenticate(with: credential) { error in
-//          if let error = error {
-//            // An error happened.
-//          } else {
-//            // User re-authenticated.
-//          }
-//        }
-    }
-
     func fireBasewithDraw() {
         let user = Auth.auth().currentUser
 

--- a/Flicker/Global/Base/BaseViewController.swift
+++ b/Flicker/Global/Base/BaseViewController.swift
@@ -128,42 +128,12 @@ class BaseViewController: UIViewController {
 }
 
 extension BaseViewController : UITextFieldDelegate {
-
-    func textFieldShouldReturn(_ textField: UITextField) -> Bool {
-        textField.resignFirstResponder()
-        return true
-    }
-
     func textFieldDidBeginEditing(_ textField: UITextField) {
         self.activeTextField = textField
     }
     
     func textFieldDidEndEditing(_ textField: UITextField) {
         self.activeTextField = nil
-    }
-    //이메일 유효성 검사
-    func emailValidCheck(_ textField: UITextField) -> Bool {
-          //맨 처음은 영어, 대문자, 소문자, 툭수문자 모두 가능하다는 뜻이며, +@는 사이에 @가 무조건 있어야 하며
-          //@ 뒤에는 대문자,소문자,숫자,.,-만 되고 . 이 온 이후는 영어대문자,소문자만 가능하며
-          //마지막은 2~64글자까지만 허용한다는 emailValid입니다.
-          let emailRegEx = "[A-Z0-9a-z._%+-]+@[A-Za-z0-9.-]+\\.[A-Za-z]{2,64}"
-          let emailTest = NSPredicate(format: "SELF MATCHES %@", emailRegEx)
-          //bool값임
-          return  emailTest.evaluate(with: textField.text)
-      }
-    //비밀번호의 길이가 6자리 이상일 경우에만 true값 전달
-    func passwordValidCheck(_ textField: UITextField) -> Bool {
-        guard let passwordCount = textField.text?.count else { return false }
-
-        if passwordCount >= 6 {
-            return true
-        } else { return false }
-    }
-
-    func passwordSameCheck(_ textField: UITextField, _ checkTextField: UITextField) -> Bool {
-        if textField.text == checkTextField.text {
-            return true
-        } else { return false }
     }
 }
 

--- a/Flicker/Global/Base/BaseViewController.swift
+++ b/Flicker/Global/Base/BaseViewController.swift
@@ -128,12 +128,42 @@ class BaseViewController: UIViewController {
 }
 
 extension BaseViewController : UITextFieldDelegate {
+
+    func textFieldShouldReturn(_ textField: UITextField) -> Bool {
+        textField.resignFirstResponder()
+        return true
+    }
+
     func textFieldDidBeginEditing(_ textField: UITextField) {
         self.activeTextField = textField
     }
     
     func textFieldDidEndEditing(_ textField: UITextField) {
         self.activeTextField = nil
+    }
+    //이메일 유효성 검사
+    func emailValidCheck(_ textField: UITextField) -> Bool {
+          //맨 처음은 영어, 대문자, 소문자, 툭수문자 모두 가능하다는 뜻이며, +@는 사이에 @가 무조건 있어야 하며
+          //@ 뒤에는 대문자,소문자,숫자,.,-만 되고 . 이 온 이후는 영어대문자,소문자만 가능하며
+          //마지막은 2~64글자까지만 허용한다는 emailValid입니다.
+          let emailRegEx = "[A-Z0-9a-z._%+-]+@[A-Za-z0-9.-]+\\.[A-Za-z]{2,64}"
+          let emailTest = NSPredicate(format: "SELF MATCHES %@", emailRegEx)
+          //bool값임
+          return  emailTest.evaluate(with: textField.text)
+      }
+    //비밀번호의 길이가 6자리 이상일 경우에만 true값 전달
+    func passwordValidCheck(_ textField: UITextField) -> Bool {
+        guard let passwordCount = textField.text?.count else { return false }
+
+        if passwordCount >= 6 {
+            return true
+        } else { return false }
+    }
+
+    func passwordSameCheck(_ textField: UITextField, _ checkTextField: UITextField) -> Bool {
+        if textField.text == checkTextField.text {
+            return true
+        } else { return false }
     }
 }
 

--- a/Flicker/Global/Base/BaseViewController.swift
+++ b/Flicker/Global/Base/BaseViewController.swift
@@ -143,3 +143,58 @@ extension BaseViewController: UIGestureRecognizerDelegate {
         return count > 1
     }
 }
+
+extension BaseViewController {
+
+    func reAuthUser() {
+        let user = Auth.auth().currentUser
+        var credential: AuthCredential
+
+        // Prompt the user to re-provide their sign-in credentials
+//
+//        user?.reauthenticate(with: credential) { error in
+//          if let error = error {
+//            // An error happened.
+//          } else {
+//            // User re-authenticated.
+//          }
+//        }
+    }
+
+    func fireBasewithDraw() {
+        let user = Auth.auth().currentUser
+
+        user?.delete { error in
+          if let error = error {
+              //회원탈퇴 실패
+              print(error)
+              print("123123")
+          } else {
+              DispatchQueue.main.async {
+                  self.goLogin()
+              }
+          }
+        }
+    }
+    
+    func fireBaseSignOut() {
+        let firebaseAuth = Auth.auth()
+        do {
+            try firebaseAuth.signOut()
+
+        } catch let signOutError as NSError {
+            print("Error signing out: %@", signOutError)
+        }
+        DispatchQueue.main.async {
+            self.goLogin()
+        }
+    }
+
+    func goLogin() {
+        let viewController = LogInViewController()
+        let navigationController = UINavigationController(rootViewController: viewController)
+        navigationController.modalPresentationStyle = .fullScreen
+        self.present(navigationController, animated: true, completion: nil)
+    }
+
+}

--- a/Flicker/Global/Base/BaseViewController.swift
+++ b/Flicker/Global/Base/BaseViewController.swift
@@ -176,6 +176,21 @@ extension BaseViewController: UIGestureRecognizerDelegate {
 
 extension BaseViewController {
 
+    func reAuthUser() {
+        let user = Auth.auth().currentUser
+        var credential: AuthCredential
+
+        // Prompt the user to re-provide their sign-in credentials
+//
+//        user?.reauthenticate(with: credential) { error in
+//          if let error = error {
+//            // An error happened.
+//          } else {
+//            // User re-authenticated.
+//          }
+//        }
+    }
+
     func fireBasewithDraw() {
         let user = Auth.auth().currentUser
 

--- a/Flicker/Global/Base/BaseViewController.swift
+++ b/Flicker/Global/Base/BaseViewController.swift
@@ -8,6 +8,10 @@
 import UIKit
 
 import Then
+import AuthenticationServices
+import Firebase
+import FirebaseAuth
+import FirebaseFirestore
 
 class BaseViewController: UIViewController {
     // MARK: - property
@@ -54,7 +58,7 @@ class BaseViewController: UIViewController {
         appearance.largeTitleTextAttributes = [.font: largeFont]
         appearance.shadowColor = .clear
         appearance.backgroundColor = .white
-
+        
         navigationBar.standardAppearance = appearance
         navigationBar.compactAppearance = appearance
         navigationBar.scrollEdgeAppearance = appearance
@@ -74,11 +78,10 @@ class BaseViewController: UIViewController {
     }
     
     // MARK: - private func
-    
     private func setupBackButton() {
         let leftOffsetBackButton = removeBarButtonItemOffset(with: backButton, offsetX: 10)
         let backButton = makeBarButtonItem(with: leftOffsetBackButton)
-
+        
         navigationItem.leftBarButtonItem = backButton
     }
     
@@ -95,7 +98,7 @@ class BaseViewController: UIViewController {
         guard let keyboardSize = (notification.userInfo?[UIResponder.keyboardFrameEndUserInfoKey] as? NSValue)?.cgRectValue else {
             
             // if keyboard size is not available for some reason, dont do anything
-           return
+            return
         }
         
         var shouldMoveViewUp = false
@@ -115,7 +118,7 @@ class BaseViewController: UIViewController {
             self.view.frame.origin.y = 0 - keyboardSize.height
         }
     }
-
+    
     @objc func keyboardWillHide(notification: NSNotification) {
         self.view.frame.origin.y = 0
     }
@@ -125,15 +128,46 @@ class BaseViewController: UIViewController {
         // ie. it will trigger a keyboardWillHide notification
         self.view.endEditing(true)
     }
+    
 }
 
 extension BaseViewController : UITextFieldDelegate {
+    
+    func textFieldShouldReturn(_ textField: UITextField) -> Bool {
+        textField.resignFirstResponder()
+        return true
+    }
+    
     func textFieldDidBeginEditing(_ textField: UITextField) {
         self.activeTextField = textField
     }
     
     func textFieldDidEndEditing(_ textField: UITextField) {
         self.activeTextField = nil
+    }
+    //이메일 유효성 검사
+    func emailValidCheck(_ textField: UITextField) -> Bool {
+        //맨 처음은 영어, 대문자, 소문자, 툭수문자 모두 가능하다는 뜻이며, +@는 사이에 @가 무조건 있어야 하며
+        //@ 뒤에는 대문자,소문자,숫자,.,-만 되고 . 이 온 이후는 영어대문자,소문자만 가능하며
+        //마지막은 2~64글자까지만 허용한다는 emailValid입니다.
+        let emailRegEx = "[A-Z0-9a-z._%+-]+@[A-Za-z0-9.-]+\\.[A-Za-z]{2,64}"
+        let emailTest = NSPredicate(format: "SELF MATCHES %@", emailRegEx)
+        //bool값임
+        return  emailTest.evaluate(with: textField.text)
+    }
+    //비밀번호의 길이가 6자리 이상일 경우에만 true값 전달
+    func passwordValidCheck(_ textField: UITextField) -> Bool {
+        guard let passwordCount = textField.text?.count else { return false }
+        
+        if passwordCount >= 6 {
+            return true
+        } else { return false }
+    }
+    
+    func passwordSameCheck(_ textField: UITextField, _ checkTextField: UITextField) -> Bool {
+        if textField.text == checkTextField.text {
+            return true
+        } else { return false }
     }
 }
 
@@ -145,35 +179,20 @@ extension BaseViewController: UIGestureRecognizerDelegate {
 }
 
 extension BaseViewController {
-
-    func reAuthUser() {
-        let user = Auth.auth().currentUser
-        var credential: AuthCredential
-
-        // Prompt the user to re-provide their sign-in credentials
-//
-//        user?.reauthenticate(with: credential) { error in
-//          if let error = error {
-//            // An error happened.
-//          } else {
-//            // User re-authenticated.
-//          }
-//        }
-    }
-
+    
     func fireBasewithDraw() {
         let user = Auth.auth().currentUser
-
+        
         user?.delete { error in
-          if let error = error {
-              //회원탈퇴 실패
-              print(error)
-              print("123123")
-          } else {
-              DispatchQueue.main.async {
-                  self.goLogin()
-              }
-          }
+            if let error = error {
+                //회원탈퇴 실패
+                print(error)
+                print("123123")
+            } else {
+                DispatchQueue.main.async {
+                    self.goLogin()
+                }
+            }
         }
     }
     
@@ -181,7 +200,7 @@ extension BaseViewController {
         let firebaseAuth = Auth.auth()
         do {
             try firebaseAuth.signOut()
-
+            
         } catch let signOutError as NSError {
             print("Error signing out: %@", signOutError)
         }
@@ -189,12 +208,12 @@ extension BaseViewController {
             self.goLogin()
         }
     }
-
+    
     func goLogin() {
         let viewController = LogInViewController()
         let navigationController = UINavigationController(rootViewController: viewController)
         navigationController.modalPresentationStyle = .fullScreen
         self.present(navigationController, animated: true, completion: nil)
     }
-
+    
 }

--- a/Flicker/Global/Supports/SceneDelegate 2.swift
+++ b/Flicker/Global/Supports/SceneDelegate 2.swift
@@ -1,0 +1,60 @@
+//
+//  SceneDelegate.swift
+//  Flicker
+//
+//  Created by COBY_PRO on 2022/10/24.
+//
+
+import UIKit
+
+import FirebaseAuth
+
+class SceneDelegate: UIResponder, UIWindowSceneDelegate {
+    
+    var window: UIWindow?
+    
+    func scene(_ scene: UIScene, willConnectTo session: UISceneSession, options connectionOptions: UIScene.ConnectionOptions) {
+        guard let windowScene = (scene as? UIWindowScene) else { return }
+        window = UIWindow(windowScene: windowScene)
+
+        let AuthController = UINavigationController(rootViewController: LogInViewController())
+<<<<<<< refs/remotes/origin/Feat/38-SignOutView
+        window?.rootViewController = Auth.auth().currentUser != nil ? TabbarViewController() : AuthController
+=======
+        // window?.rootViewController = Auth.auth().currentUser != nil ? TabbarViewController() : AuthController
+        window?.rootViewController = TabbarViewController()
+        // window?.rootViewController = RegisterWelcomeViewController()
+>>>>>>> :art: 유저의 상태에 따라 테이블 셀을 변화시킵니다.
+        window?.makeKeyAndVisible()
+    }
+    
+    func sceneDidDisconnect(_ scene: UIScene) {
+        // Called as the scene is being released by the system.
+        // This occurs shortly after the scene enters the background, or when its session is discarded.
+        // Release any resources associated with this scene that can be re-created the next time the scene connects.
+        // The scene may re-connect later, as its session was not necessarily discarded (see `application:didDiscardSceneSessions` instead).
+    }
+    
+    func sceneDidBecomeActive(_ scene: UIScene) {
+        // Called when the scene has moved from an inactive state to an active state.
+        // Use this method to restart any tasks that were paused (or not yet started) when the scene was inactive.
+    }
+    
+    func sceneWillResignActive(_ scene: UIScene) {
+        // Called when the scene will move from an active state to an inactive state.
+        // This may occur due to temporary interruptions (ex. an incoming phone call).
+    }
+    
+    func sceneWillEnterForeground(_ scene: UIScene) {
+        // Called as the scene transitions from the background to the foreground.
+        // Use this method to undo the changes made on entering the background.
+    }
+    
+    func sceneDidEnterBackground(_ scene: UIScene) {
+        // Called as the scene transitions from the foreground to the background.
+        // Use this method to save data, release shared resources, and store enough scene-specific state information
+        // to restore the scene back to its current state.
+    }
+    
+    
+}

--- a/Flicker/Global/Supports/SceneDelegate.swift
+++ b/Flicker/Global/Supports/SceneDelegate.swift
@@ -22,6 +22,8 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
 
         let AuthController = UINavigationController(rootViewController: LogInViewController())
         window?.rootViewController = Auth.auth().currentUser != nil ? TabbarViewController() : AuthController
+
+//        window?.rootViewController = InputPasswordViewController()
         window?.makeKeyAndVisible()
     }
     

--- a/Flicker/Global/Supports/SceneDelegate.swift
+++ b/Flicker/Global/Supports/SceneDelegate.swift
@@ -20,6 +20,8 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         let AuthController = UINavigationController(rootViewController: LogInViewController())
         window?.rootViewController = TabbarViewController()
 
+        let AuthController = UINavigationController(rootViewController: LogInViewController())
+        window?.rootViewController = Auth.auth().currentUser != nil ? TabbarViewController() : AuthController
         window?.makeKeyAndVisible()
     }
     

--- a/Flicker/Global/Supports/SceneDelegate.swift
+++ b/Flicker/Global/Supports/SceneDelegate.swift
@@ -17,10 +17,10 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         guard let windowScene = (scene as? UIWindowScene) else { return }
         window = UIWindow(windowScene: windowScene)
 
-//        let AuthController = UINavigationController(rootViewController: LogInViewController())
-//        window?.rootViewController = Auth.auth().currentUser != nil ? TabbarViewController() : AuthController
+        let AuthController = UINavigationController(rootViewController: LogInViewController())
+        window?.rootViewController = Auth.auth().currentUser != nil ? TabbarViewController() : AuthController
 
-        window?.rootViewController = WithDrawViewController()
+//        window?.rootViewController = WithDrawViewController()
         window?.makeKeyAndVisible()
     }
     

--- a/Flicker/Global/Supports/SceneDelegate.swift
+++ b/Flicker/Global/Supports/SceneDelegate.swift
@@ -17,8 +17,10 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         guard let windowScene = (scene as? UIWindowScene) else { return }
         window = UIWindow(windowScene: windowScene)
 
-        let AuthController = UINavigationController(rootViewController: LogInViewController())
-        window?.rootViewController = Auth.auth().currentUser != nil ? TabbarViewController() : AuthController
+//        let AuthController = UINavigationController(rootViewController: LogInViewController())
+//        window?.rootViewController = Auth.auth().currentUser != nil ? TabbarViewController() : AuthController
+
+        window?.rootViewController = WithDrawViewController()
         window?.makeKeyAndVisible()
     }
     

--- a/Flicker/Global/Supports/SceneDelegate.swift
+++ b/Flicker/Global/Supports/SceneDelegate.swift
@@ -16,14 +16,9 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
     func scene(_ scene: UIScene, willConnectTo session: UISceneSession, options connectionOptions: UIScene.ConnectionOptions) {
         guard let windowScene = (scene as? UIWindowScene) else { return }
         window = UIWindow(windowScene: windowScene)
-        
-        let AuthController = UINavigationController(rootViewController: LogInViewController())
-        window?.rootViewController = TabbarViewController()
 
         let AuthController = UINavigationController(rootViewController: LogInViewController())
         window?.rootViewController = Auth.auth().currentUser != nil ? TabbarViewController() : AuthController
-
-//        window?.rootViewController = InputPasswordViewController()
         window?.makeKeyAndVisible()
     }
     

--- a/Flicker/Global/Utils/AppleLoginManager.swift
+++ b/Flicker/Global/Utils/AppleLoginManager.swift
@@ -1,0 +1,79 @@
+////
+////  AppleLoginManager.swift
+////  Flicker
+////
+////  Created by 김연호 on 2022/11/17.
+////
+//
+//import UIKit
+//
+//import AuthenticationServices
+//import CryptoKit
+//import Firebase
+//import FirebaseAuth
+//import FirebaseFirestore
+//
+//final class AppleLoginManager: NSObject {
+//    static let shared = AppleLoginManager()
+//
+//    fileprivate var currentNonce: String?
+//    
+//
+//    @available(iOS 13, *)
+//    func createAppleIDRequest() -> ASAuthorizationAppleIDRequest {
+//        let appleIDProvider = ASAuthorizationAppleIDProvider()
+//        let request = appleIDProvider.createRequest()
+//        // 애플로그인은 사용자에게서 2가지 정보를 요구함
+//        request.requestedScopes = [.fullName, .email]
+//
+//        let nonce = randomNonceString()
+//        request.nonce = sha256(nonce)
+//        currentNonce = nonce
+//
+//        return request
+//    }
+//
+//    @available(iOS 13, *)
+//    private func sha256(_ input: String) -> String {
+//        let inputData = Data(input.utf8)
+//        let hashedData = SHA256.hash(data: inputData)
+//        let hashString = hashedData.compactMap {
+//            return String(format: "%02x", $0)
+//        }.joined()
+//
+//        return hashString
+//    }
+//
+//    private func randomNonceString(length: Int = 32) -> String {
+//        precondition(length > 0)
+//        let charset: Array<Character> =
+//        Array("0123456789ABCDEFGHIJKLMNOPQRSTUVXYZabcdefghijklmnopqrstuvwxyz-._")
+//        var result = ""
+//        var remainingLength = length
+//
+//        while remainingLength > 0 {
+//            let randoms: [UInt8] = (0 ..< 16).map { _ in
+//                var random: UInt8 = 0
+//                let errorCode = SecRandomCopyBytes(kSecRandomDefault, 1, &random)
+//                if errorCode != errSecSuccess {
+//                    fatalError("Unable to generate nonce. SecRandomCopyBytes failed with OSStatus \(errorCode)")
+//                }
+//                return random
+//            }
+//
+//            randoms.forEach { random in
+//                if remainingLength == 0 {
+//                    return
+//                }
+//
+//                if random < charset.count {
+//                    result.append(charset[Int(random)])
+//                    remainingLength -= 1
+//                }
+//            }
+//        }
+//
+//        return result
+//    }
+//
+//}

--- a/Flicker/Global/Utils/FirebaseManager.swift
+++ b/Flicker/Global/Utils/FirebaseManager.swift
@@ -70,6 +70,11 @@ final class FirebaseManager: NSObject {
             
             try await firestore.collection("users").document(uid).setData(userData)
         } catch {
+//            print(email)
+//            print(name)
+//            print(uid)
+//            print(profileImage)
+//            print(error)
             print("Store User error")
         }
     }

--- a/Flicker/Screens/Login/LoginViewController.swift
+++ b/Flicker/Screens/Login/LoginViewController.swift
@@ -17,7 +17,10 @@ import FirebaseFirestore
 
 final class LogInViewController: BaseViewController {
 
-    fileprivate var currentNonce: String?
+    static let shared = LogInViewController()
+
+    var currentNonce: String?
+    var currentAppleIdToken: String?
 
     private lazy var appleLoginButton = ASAuthorizationAppleIDButton(type: .signIn, style: .black).then {
         $0.addTarget(self, action: #selector(handleAuthorizationAppleIDButtonPress), for: .touchUpInside)
@@ -303,7 +306,7 @@ extension LogInViewController: ASAuthorizationControllerDelegate, ASAuthorizatio
             }
             //문자열로 변환
             guard let idTokenString = String(data: appleIDtoken, encoding: .utf8) else {
-                print("Unable to serialize token string from data: \(appleIDtoken.debugDescription)")
+                print("Unable to serialize token string from data: \(currentAppleIdToken.debugDescription)")
                 return
             }
 
@@ -315,6 +318,7 @@ extension LogInViewController: ASAuthorizationControllerDelegate, ASAuthorizatio
                 if let user = authDataResult?.user {
                     //로그인 성공 시
                     self.goProfile()
+                    self.currentAppleIdToken = idTokenString
                 }
 
                 if error != nil {

--- a/Flicker/Screens/Login/LoginViewController.swift
+++ b/Flicker/Screens/Login/LoginViewController.swift
@@ -49,7 +49,7 @@ final class LogInViewController: BaseViewController {
             NSAttributedString.Key.foregroundColor : UIColor.white,
             NSAttributedString.Key.font : UIFont.systemFont(ofSize: 17, weight: .bold)
         ]
-
+        $0.autocorrectionType = .no
         $0.backgroundColor = .loginGray
         $0.attributedPlaceholder = NSAttributedString(string: "이메일 주소", attributes: attributes)
         $0.autocapitalizationType = .none
@@ -66,7 +66,7 @@ final class LogInViewController: BaseViewController {
             NSAttributedString.Key.foregroundColor : UIColor.white,
             NSAttributedString.Key.font : UIFont.systemFont(ofSize: 17, weight: .bold)
         ]
-
+        $0.autocorrectionType = .no
         $0.backgroundColor = .loginGray
         $0.attributedPlaceholder = NSAttributedString(string: "비밀번호", attributes: attributes)
         $0.layer.cornerRadius = 12

--- a/Flicker/Screens/Login/LoginViewController.swift
+++ b/Flicker/Screens/Login/LoginViewController.swift
@@ -289,7 +289,7 @@ extension LogInViewController: ASAuthorizationControllerDelegate, ASAuthorizatio
     }
 
 
-// 사용자 인증 후 처리
+    // 사용자 인증 후 처리
     func authorizationController(controller: ASAuthorizationController, didCompleteWithAuthorization authorization: ASAuthorization) {
         if let appleIDCredential = authorization.credential as? ASAuthorizationAppleIDCredential {
             // 현재 nonce가 설정되어 있는지 확인
@@ -329,33 +329,33 @@ extension LogInViewController: ASAuthorizationControllerDelegate, ASAuthorizatio
 //임의로 생성되는 암호화 토큰이다.
 
 private func randomNonceString(length: Int = 32) -> String {
-  precondition(length > 0)
-  let charset: Array<Character> =
-      Array("0123456789ABCDEFGHIJKLMNOPQRSTUVXYZabcdefghijklmnopqrstuvwxyz-._")
-  var result = ""
-  var remainingLength = length
+    precondition(length > 0)
+    let charset: Array<Character> =
+    Array("0123456789ABCDEFGHIJKLMNOPQRSTUVXYZabcdefghijklmnopqrstuvwxyz-._")
+    var result = ""
+    var remainingLength = length
 
-  while remainingLength > 0 {
-    let randoms: [UInt8] = (0 ..< 16).map { _ in
-      var random: UInt8 = 0
-      let errorCode = SecRandomCopyBytes(kSecRandomDefault, 1, &random)
-      if errorCode != errSecSuccess {
-        fatalError("Unable to generate nonce. SecRandomCopyBytes failed with OSStatus \(errorCode)")
-      }
-      return random
+    while remainingLength > 0 {
+        let randoms: [UInt8] = (0 ..< 16).map { _ in
+            var random: UInt8 = 0
+            let errorCode = SecRandomCopyBytes(kSecRandomDefault, 1, &random)
+            if errorCode != errSecSuccess {
+                fatalError("Unable to generate nonce. SecRandomCopyBytes failed with OSStatus \(errorCode)")
+            }
+            return random
+        }
+
+        randoms.forEach { random in
+            if remainingLength == 0 {
+                return
+            }
+
+            if random < charset.count {
+                result.append(charset[Int(random)])
+                remainingLength -= 1
+            }
+        }
     }
 
-    randoms.forEach { random in
-      if remainingLength == 0 {
-        return
-      }
-
-      if random < charset.count {
-        result.append(charset[Int(random)])
-        remainingLength -= 1
-      }
-    }
-  }
-
-  return result
+    return result
 }

--- a/Flicker/Screens/Profile/ProfileViewController.swift
+++ b/Flicker/Screens/Profile/ProfileViewController.swift
@@ -58,9 +58,9 @@ final class ProfileViewController: BaseViewController {
     }
     // MARK: - Setting Functions
     @objc func didTapGesture() {
-        print("asdf")
-        navigationController?
-            .pushViewController(LoginProfileViewController(), animated: true)
+        let viewController = InputPasswordViewController()
+        let modalNavigationController = UINavigationController(rootViewController: viewController)
+        present(modalNavigationController, animated: true)
     }
     @objc func didToggleSwitch(_ sender: UISwitch) {
         print(sender.isOn)

--- a/Flicker/Screens/ProfileSetting/InputPassword/InputPasswordViewController.swift
+++ b/Flicker/Screens/ProfileSetting/InputPassword/InputPasswordViewController.swift
@@ -22,7 +22,7 @@ final class InputPasswordViewController: BaseViewController {
 
     private let firstSubLabel = UILabel().makeBasicLabel(labelText: "개인정보를 안전하게 보호하기 위하여", textColor: .textSubBlack, fontStyle: .callout, fontWeight: .bold)
 
-    private let secondSubLabel = UILabel().makeBasicLabel(labelText: "SUGGLE 아이디 비밀번호를 한번 더 입력해주세요.", textColor: .textSubBlack, fontStyle: .callout, fontWeight: .bold)
+    private let secondSubLabel = UILabel().makeBasicLabel(labelText: "SHUGGLE 아이디 비밀번호를 한번 더 입력해주세요.", textColor: .textSubBlack, fontStyle: .callout, fontWeight: .bold)
 
     private let passwordField = UITextField().then {
         let attributes = [
@@ -61,7 +61,7 @@ final class InputPasswordViewController: BaseViewController {
         }
 
         mainLabel.snp.makeConstraints {
-            $0.top.equalTo(view.safeAreaLayoutGuide.snp.top).offset(10)
+            $0.top.equalTo(view.snp.centerY).offset(-250)
             $0.leading.equalToSuperview().inset(20)
         }
 
@@ -76,13 +76,13 @@ final class InputPasswordViewController: BaseViewController {
         }
 
         passwordField.snp.makeConstraints {
-            $0.top.equalTo(secondSubLabel.snp.bottom).offset(15)
+            $0.top.equalTo(secondSubLabel.snp.bottom).offset(30)
             $0.leading.trailing.equalToSuperview().inset(20)
             $0.height.equalTo(60)
         }
 
         certifiedButton.snp.makeConstraints {
-            $0.top.equalTo(passwordField.snp.bottom).offset(15)
+            $0.top.equalTo(passwordField.snp.bottom).offset(30)
             $0.leading.trailing.equalToSuperview().inset(20)
             $0.height.equalTo(60)
         }

--- a/Flicker/Screens/ProfileSetting/InputPassword/InputPasswordViewController.swift
+++ b/Flicker/Screens/ProfileSetting/InputPassword/InputPasswordViewController.swift
@@ -118,13 +118,13 @@ final class InputPasswordViewController: BaseViewController {
         let credential = EmailAuthProvider.credential(withEmail: userEmail!, password: userPw!)
 
         user?.reauthenticate(with: credential) { _,error  in
-          if let error = error {
-              print(error)
-              self.makeAlert(title: "비밀번호를 확인해주세요", message: "")
-          } else {
-            let viewController = ProfileSettingViewController()
-            self.navigationController?.pushViewController(viewController, animated: true)
-          }
+            if let error = error {
+                print(error)
+                self.makeAlert(title: "비밀번호를 확인해주세요", message: "")
+            } else {
+                let viewController = ProfileSettingViewController()
+                self.navigationController?.pushViewController(viewController, animated: true)
+            }
         }
     }
 }

--- a/Flicker/Screens/ProfileSetting/InputPassword/InputPasswordViewController.swift
+++ b/Flicker/Screens/ProfileSetting/InputPassword/InputPasswordViewController.swift
@@ -1,0 +1,64 @@
+//
+//  InputPasswordViewController.swift
+//  Flicker
+//
+//  Created by 김연호 on 2022/11/16.
+//
+import UIKit
+
+import SnapKit
+import Then
+import AuthenticationServices
+import Firebase
+import FirebaseAuth
+
+final class InputPasswordViewController: BaseViewController {
+
+    private let navigationDivider = UIView().then {
+        $0.backgroundColor = .loginGray
+    }
+
+    private let mainLabel = UILabel().makeBasicLabel(labelText: "아이디 재인증", textColor: .textMainBlack, fontStyle: .title3, fontWeight: .bold)
+
+    private let firstSubLabel = UILabel().makeBasicLabel(labelText: "개인정보를 안전하게 보호하기 위하여", textColor: .textSubBlack, fontStyle: .callout, fontWeight: .bold)
+
+    private let secondSubLabel = UILabel().makeBasicLabel(labelText: "SUGGLE 아이디 비밀번호를 한번 더 입력해주세요.", textColor: .textSubBlack, fontStyle: .callout, fontWeight: .bold)
+
+    private let certifiedButton = UIButton().then {
+        $0.backgroundColor = .mainPink
+        $0.setTitleColor(.white, for: .normal)
+        $0.setTitle("확인", for: .normal)
+        $0.layer.cornerRadius = 15
+    }
+
+    override func render() {
+
+        view.addSubviews(navigationDivider, mainLabel, firstSubLabel, secondSubLabel, certifiedButton)
+
+        certifiedButton.addTarget(self, action: #selector(didTapSignInbutton), for: .touchUpInside)
+
+    }
+
+    override func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
+    }
+
+    override func viewWillDisappear(_ animated: Bool) {
+        super.viewWillDisappear(animated)
+        navigationController?.setNavigationBarHidden(true, animated: false)
+    }
+
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        navigationController?.setNavigationBarHidden(true, animated: false)
+    }
+
+    override func setupNavigationBar() {
+        super.setupNavigationBar()
+        title = "정보관리"
+    }
+
+    @objc private func didTapSignInbutton() {
+    }
+
+}

--- a/Flicker/Screens/ProfileSetting/InputPassword/InputPasswordViewController.swift
+++ b/Flicker/Screens/ProfileSetting/InputPassword/InputPasswordViewController.swift
@@ -24,19 +24,68 @@ final class InputPasswordViewController: BaseViewController {
 
     private let secondSubLabel = UILabel().makeBasicLabel(labelText: "SUGGLE 아이디 비밀번호를 한번 더 입력해주세요.", textColor: .textSubBlack, fontStyle: .callout, fontWeight: .bold)
 
+    private let passwordField = UITextField().then {
+        let attributes = [
+            NSAttributedString.Key.foregroundColor : UIColor.white,
+            NSAttributedString.Key.font : UIFont.systemFont(ofSize: 17, weight: .bold)
+        ]
+        $0.autocorrectionType = .no
+        $0.backgroundColor = .loginGray
+        $0.attributedPlaceholder = NSAttributedString(string: "비밀번호 입력", attributes: attributes)
+        $0.layer.cornerRadius = 10
+        $0.layer.masksToBounds = true
+        $0.leftView = UIView(frame: CGRect(x: 0, y: 0, width: 10, height: 0))
+        $0.leftViewMode = .always
+        $0.clipsToBounds = false
+        $0.isSecureTextEntry = true
+        $0.makeShadow(color: .black, opacity: 0.08, offset: CGSize(width: 0, height: 4), radius: 20)
+    }
+
     private let certifiedButton = UIButton().then {
         $0.backgroundColor = .mainPink
         $0.setTitleColor(.white, for: .normal)
         $0.setTitle("확인", for: .normal)
-        $0.layer.cornerRadius = 15
+        $0.layer.cornerRadius = 10
     }
 
     override func render() {
 
-        view.addSubviews(navigationDivider, mainLabel, firstSubLabel, secondSubLabel, certifiedButton)
+        view.addSubviews(navigationDivider, mainLabel, firstSubLabel, secondSubLabel, passwordField,certifiedButton)
 
         certifiedButton.addTarget(self, action: #selector(didTapSignInbutton), for: .touchUpInside)
 
+        navigationDivider.snp.makeConstraints {
+            $0.top.equalTo(view.safeAreaLayoutGuide.snp.top)
+            $0.leading.trailing.equalToSuperview()
+            $0.height.equalTo(2)
+        }
+
+        mainLabel.snp.makeConstraints {
+            $0.top.equalTo(view.safeAreaLayoutGuide.snp.top).offset(10)
+            $0.leading.equalToSuperview().inset(20)
+        }
+
+        firstSubLabel.snp.makeConstraints {
+            $0.top.equalTo(mainLabel.snp.bottom).offset(20)
+            $0.centerX.equalTo(view.snp.centerX)
+        }
+
+        secondSubLabel.snp.makeConstraints {
+            $0.top.equalTo(firstSubLabel.snp.bottom).offset(5)
+            $0.centerX.equalTo(view.snp.centerX)
+        }
+
+        passwordField.snp.makeConstraints {
+            $0.top.equalTo(secondSubLabel.snp.bottom).offset(15)
+            $0.leading.trailing.equalToSuperview().inset(20)
+            $0.height.equalTo(60)
+        }
+
+        certifiedButton.snp.makeConstraints {
+            $0.top.equalTo(passwordField.snp.bottom).offset(15)
+            $0.leading.trailing.equalToSuperview().inset(20)
+            $0.height.equalTo(60)
+        }
     }
 
     override func viewDidAppear(_ animated: Bool) {
@@ -59,6 +108,23 @@ final class InputPasswordViewController: BaseViewController {
     }
 
     @objc private func didTapSignInbutton() {
+        reAuthUser()
     }
+    //사용자 재인증 함수, 이메일은 파베에서 가져오고 비밀번호는 사용자가 입력 한 후, 비밀번호가 틀릴 시 재입력요구, 성공하면 ProfileSettingView로 넘어감
+    private func reAuthUser() {
+        let user = Auth.auth().currentUser
+        let userEmail = user?.email
+        let userPw = passwordField.text
+        let credential = EmailAuthProvider.credential(withEmail: userEmail!, password: userPw!)
 
+        user?.reauthenticate(with: credential) { _,error  in
+          if let error = error {
+              print(error)
+              self.makeAlert(title: "비밀번호를 확인해주세요", message: "")
+          } else {
+            let viewController = ProfileSettingViewController()
+            self.navigationController?.pushViewController(viewController, animated: true)
+          }
+        }
+    }
 }

--- a/Flicker/Screens/ProfileSetting/InputPassword/InputPasswordViewController.swift
+++ b/Flicker/Screens/ProfileSetting/InputPassword/InputPasswordViewController.swift
@@ -108,7 +108,11 @@ final class InputPasswordViewController: BaseViewController {
     }
 
     @objc private func didTapSignInbutton() {
-        reAuthUser()
+        //TODO: -
+        // 애플재인증과 이메일 재인증을 분기처리하기 위해 서버에 이메일,애플로그인 구별을 하던
+        // 코어데이터를 활용해서 하든 이메일로그인 인지 애플로그인 인지 식별을 해야함
+//        reAuthUser()
+        appleLoginReAuthUser()
     }
     //사용자 재인증 함수, 이메일은 파베에서 가져오고 비밀번호는 사용자가 입력 한 후, 비밀번호가 틀릴 시 재입력요구, 성공하면 ProfileSettingView로 넘어감
     private func reAuthUser() {
@@ -122,9 +126,27 @@ final class InputPasswordViewController: BaseViewController {
                 print(error)
                 self.makeAlert(title: "비밀번호를 확인해주세요", message: "")
             } else {
-                let viewController = ProfileSettingViewController()
-                self.navigationController?.pushViewController(viewController, animated: true)
+                Task{ [weak self] in
+//                    self?.dismiss(animated:true, completion:nil )
+                    let viewController = ProfileSettingViewController()
+                    self?.navigationController?.pushViewController(viewController, animated: true)
+                }
             }
+        }
+    }
+    //애플 재인증 함수
+    private func appleLoginReAuthUser() {
+        // Initialize a fresh Apple credential with Firebase.
+        let credential = OAuthProvider.credential(
+          withProviderID: "apple.com",
+          idToken: LogInViewController.shared.currentAppleIdToken ?? "",
+          rawNonce: LogInViewController.shared.currentNonce
+        )
+        // Reauthenticate current Apple user with fresh Apple credential.
+        Auth.auth().currentUser?.reauthenticate(with: credential) { (authResult, error) in
+            guard error != nil else { return }
+            let viewController = ProfileSettingViewController()
+            self.navigationController?.pushViewController(viewController, animated: true)
         }
     }
 }

--- a/Flicker/Screens/ProfileSetting/ProfileSettingViewController.swift
+++ b/Flicker/Screens/ProfileSetting/ProfileSettingViewController.swift
@@ -102,13 +102,13 @@ final class ProfileSettingViewController: BaseViewController {
 
     private let logOutButton = UIButton().then {
         $0.setTitle("로그아웃", for: .normal)
-        $0.setTitleColor( .textSubBlack, for: .normal)
+        $0.setTitleColor( .textMainBlack, for: .normal)
         $0.backgroundColor = .clear
     }
 
     private let withDrawButton = UIButton().then {
         $0.setTitle("회원탈퇴", for: .normal)
-        $0.setTitleColor( .textSubBlack, for: .normal)
+        $0.setTitleColor( .red, for: .normal)
         $0.backgroundColor = .clear
     }
 
@@ -117,7 +117,7 @@ final class ProfileSettingViewController: BaseViewController {
         signUpButton.isEnabled = false
         nickNameTextFieldClearButton.isHidden = true
 
-        view.addSubviews(profileImageView, cameraImage ,profileLabelFirst, profileLabelSecond, nickNameLabel, isArtistLabel, afterJoinLabel, nickNameField, artistTrueButton, artistFalseButton, signUpButton, navigationDivider, nickNameTextFieldClearButton, nickNameDivider, logOutButton, withDrawButton)
+        view.addSubviews(profileImageView, cameraImage ,profileLabelFirst, profileLabelSecond, nickNameLabel, isArtistLabel, afterJoinLabel, nickNameField, artistTrueButton, artistFalseButton, signUpButton, nickNameTextFieldClearButton, nickNameDivider, logOutButton, withDrawButton)
 
 
         artistTrueButton.addTarget(self, action: #selector(didTapArtistTrueButton), for: .touchUpInside)
@@ -127,14 +127,9 @@ final class ProfileSettingViewController: BaseViewController {
         logOutButton.addTarget(self, action: #selector(didTapLogOutButton), for: .touchUpInside)
         withDrawButton.addTarget(self, action: #selector(didTapWithDrawButton), for: .touchUpInside)
 
-        navigationDivider.snp.makeConstraints {
-            $0.top.equalTo(view.safeAreaLayoutGuide.snp.top)
-            $0.leading.trailing.equalToSuperview()
-            $0.height.equalTo(2)
-        }
 
         profileImageView.snp.makeConstraints {
-            $0.top.equalTo(view.safeAreaLayoutGuide.snp.top).offset(30)
+            $0.top.equalTo(view.safeAreaLayoutGuide.snp.top).offset(60)
             $0.centerX.equalToSuperview()
             $0.width.height.equalTo(100)
         }

--- a/Flicker/Screens/ProfileSetting/ProfileSettingViewController.swift
+++ b/Flicker/Screens/ProfileSetting/ProfileSettingViewController.swift
@@ -2,21 +2,18 @@
 //  ProfileSettingViewController.swift
 //  Flicker
 //
-//  Created by 김연호 on 2022/11/02.
+//  Created by 김연호 on 2022/11/16.
 //
-
 import UIKit
 
 import SnapKit
 import Then
-
-final class LoginProfileViewController: BaseViewController {
-
-    //이전 뷰에서 데이터를 전달받는 변수들
-    var isSignUpEmail: Bool = false
-    var authEmail: String = ""
-    var authPassword: String = ""
-
+import FirebaseAuth
+/*
+ LoginProfileViewController와 같은 뷰이지만 재사용성을 강조해 두 뷰를 종속시키는 것 보다
+ 그냥 같은 뷰를 새로 그려 따로 관리하는 것이 더 효율적이라고 생각이 되어 거의 같은 코드를 쓰는 뷰가 두 개가 있습니다.
+ */
+final class ProfileSettingViewController: BaseViewController {
     private var isNickNameWrite = false
 
     private lazy var imagePicker = UIImagePickerController().then {
@@ -52,7 +49,7 @@ final class LoginProfileViewController: BaseViewController {
     private let nickNameLabel = UILabel().makeBasicLabel(labelText: "닉네임", textColor: .black, fontStyle: .title3, fontWeight: .bold)
     private let isArtistLabel = UILabel().makeBasicLabel(labelText: "사진작가로 활동할 예정이신가요?", textColor: .black, fontStyle: .title3, fontWeight: .bold)
     private let afterJoinLabel = UILabel().makeBasicLabel(labelText: "가입 후 마이프로필에서 작가등록을 하실 수 있어요!", textColor: .textSubBlack, fontStyle: .caption1, fontWeight: .medium)
-    
+
     private let nickNameField = UITextField().then {
         let attributes = [
             NSAttributedString.Key.foregroundColor : UIColor.textSubBlack,
@@ -60,14 +57,13 @@ final class LoginProfileViewController: BaseViewController {
         ]
 
         $0.backgroundColor = .clear
-        $0.attributedPlaceholder = NSAttributedString(string: "닉네임을 입력 해 주세요!", attributes: attributes)
+        $0.attributedPlaceholder = NSAttributedString(string: "닉네임을 입력해 주세요!", attributes: attributes)
         $0.autocapitalizationType = .none
         $0.layer.masksToBounds = true
         $0.leftView = UIView(frame: CGRect(x: 0, y: 0, width: 5, height: 0))
         $0.leftViewMode = .always
         $0.clipsToBounds = false
         $0.makeShadow(color: .black, opacity: 0.08, offset: CGSize(width: 0, height: 4), radius: 20)
-        $0.autocorrectionType = .no
     }
 
     private let nickNameTextFieldClearButton = UIButton().then {
@@ -92,7 +88,7 @@ final class LoginProfileViewController: BaseViewController {
     private let signUpButton = UIButton().then {
         $0.backgroundColor = .loginGray
         $0.setTitleColor(.white, for: .normal)
-        $0.setTitle("완료", for: .normal)
+        $0.setTitle("수정 완료", for: .normal)
         $0.layer.cornerRadius = 15
     }
 
@@ -104,19 +100,32 @@ final class LoginProfileViewController: BaseViewController {
         $0.backgroundColor = .loginGray
     }
 
+    private let logOutButton = UIButton().then {
+        $0.setTitle("로그아웃", for: .normal)
+        $0.setTitleColor( .textSubBlack, for: .normal)
+        $0.backgroundColor = .clear
+    }
+
+    private let withDrawButton = UIButton().then {
+        $0.setTitle("회원탈퇴", for: .normal)
+        $0.setTitleColor( .textSubBlack, for: .normal)
+        $0.backgroundColor = .clear
+    }
+
     override func render() {
         nickNameField.delegate = self
-
         signUpButton.isEnabled = false
         nickNameTextFieldClearButton.isHidden = true
-        
-        view.addSubviews(profileImageView, cameraImage ,profileLabelFirst, profileLabelSecond, nickNameLabel, isArtistLabel, afterJoinLabel, nickNameField, artistTrueButton, artistFalseButton, signUpButton, navigationDivider, nickNameTextFieldClearButton, nickNameDivider)
+
+        view.addSubviews(profileImageView, cameraImage ,profileLabelFirst, profileLabelSecond, nickNameLabel, isArtistLabel, afterJoinLabel, nickNameField, artistTrueButton, artistFalseButton, signUpButton, navigationDivider, nickNameTextFieldClearButton, nickNameDivider, logOutButton, withDrawButton)
 
 
         artistTrueButton.addTarget(self, action: #selector(didTapArtistTrueButton), for: .touchUpInside)
         artistFalseButton.addTarget(self, action: #selector(didTapArtistFalseButton), for: .touchUpInside)
         signUpButton.addTarget(self, action: #selector(didTapSignUpButton), for: .touchUpInside)
         nickNameTextFieldClearButton.addTarget(self, action: #selector(didTapClearButton), for: .touchUpInside)
+        logOutButton.addTarget(self, action: #selector(didTapLogOutButton), for: .touchUpInside)
+        withDrawButton.addTarget(self, action: #selector(didTapWithDrawButton), for: .touchUpInside)
 
         navigationDivider.snp.makeConstraints {
             $0.top.equalTo(view.safeAreaLayoutGuide.snp.top)
@@ -182,13 +191,13 @@ final class LoginProfileViewController: BaseViewController {
         artistTrueButton.snp.makeConstraints {
             $0.top.equalTo(afterJoinLabel.snp.bottom).offset(10)
             $0.leading.equalToSuperview().inset(20)
-            $0.width.equalTo(170)
+            $0.trailing.equalTo(view.snp.centerX).inset(25 )
         }
 
         artistFalseButton.snp.makeConstraints {
             $0.top.equalTo(afterJoinLabel.snp.bottom).offset(10)
             $0.trailing.equalToSuperview().inset(20)
-            $0.width.equalTo(170)
+            $0.leading.equalTo(view.snp.centerX).offset(10)
         }
 
         signUpButton.snp.makeConstraints {
@@ -196,27 +205,25 @@ final class LoginProfileViewController: BaseViewController {
             $0.leading.trailing.equalToSuperview().inset(20)
             $0.height.equalTo(50)
         }
-    }
-        override func viewDidAppear(_ animated: Bool) {
-            super.viewDidAppear(animated)
+
+        logOutButton.snp.makeConstraints {
+            $0.top.equalTo(signUpButton.snp.bottom).offset(10)
+            $0.trailing.equalTo(view.snp.centerX).offset(-25)
         }
 
-        override func setupNavigationBar() {
-            super.setupNavigationBar()
-
-    override func viewWillDisappear(_ animated: Bool) {
-        super.viewWillDisappear(animated)
-        navigationController?.setNavigationBarHidden(true, animated: false)
+        withDrawButton.snp.makeConstraints {
+            $0.top.equalTo(signUpButton.snp.bottom).offset(10)
+            $0.leading.equalTo(view.snp.centerX).offset(25)
+        }
     }
 
-    override func viewWillAppear(_ animated: Bool) {
-        super.viewWillAppear(animated)
-        navigationController?.setNavigationBarHidden(false, animated: false)
+    override func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
     }
 
     override func setupNavigationBar() {
         super.setupNavigationBar()
-        title = "프로필 입력"
+        title = "프로필 수정"
     }
 
     @objc private func selectButtonTouched(_ recognizer: UITapGestureRecognizer) {
@@ -246,45 +253,34 @@ final class LoginProfileViewController: BaseViewController {
             signUpButton.backgroundColor = .mainPink
         }
     }
-    //TODO: profileImage가 없을 경우 이미지 값을 SFSymbol에서 받으려고 하는데 그 값조차 옵셔널 값으로 인식함 그래서 일단 강제언래핑 해놓음
+//TODO: profileImage가 없을 경우 이미지 값을 SFSymbol에서 받으려고 하는데 그 값조차 옵셔널 값으로 인식함 그래서 일단 강제언래핑 해놓음
     @objc private func didTapSignUpButton() {
-        let viewController = TabbarViewController()
-        //애플 로그인을 통해 로그인을 할 경우 LoginProfileVC에 들어왔을 때 이미 로그인이 되어있어 creatNewAccount를 할 필요가 없으며,
-        //storeUserInformation을 하기 위해 이메일 값을 파이어베이스에서 이메일 값을 가져온다.
-        if isSignUpEmail {
-            Task { [weak self] in
-                await FirebaseManager.shared.createNewAccount(email: authEmail, password: authPassword)
-                await FirebaseManager.shared.storeUserInformation(email: authEmail,
-                                                                  name: nickNameField.text ?? "",
-                                                                  profileImage: profileImageView.image ?? UIImage(systemName: "person")! )
-                self?.navigationController?.pushViewController(viewController, animated: true)
-            }
-        } else {
-            let fireBaseUser = Auth.auth().currentUser
-            Task { [weak self] in
-                if let fireBaseUser = fireBaseUser {
-                    let email = fireBaseUser.email
-                }
-                await FirebaseManager.shared.storeUserInformation(email: fireBaseUser?.email ?? "",
-                                                                  name: nickNameField.text ?? "",
-                                                                  profileImage: profileImageView.image ?? UIImage(systemName: "person")! )
-                self?.navigationController?.pushViewController(viewController, animated: true)
-            }
-        }
+        self.dismiss(animated: true, completion: nil)
     }
 
     @objc private func didTapClearButton() {
         self.nickNameField.text = ""
     }
+
+    @objc private func didTapLogOutButton() {
+        makeRequestAlert(title: "로그아웃 하시겠어요?", message: "", okAction: { _ in self.fireBaseSignOut()
+        })
+    }
+
+    @objc private func didTapWithDrawButton() {
+        let viewController = WithDrawViewController()
+        self.navigationController?.pushViewController(viewController, animated: true)
+    }
+
 }
 
-extension LoginProfileViewController: UIImagePickerControllerDelegate, UINavigationControllerDelegate {
+extension ProfileSettingViewController : UIImagePickerControllerDelegate, UINavigationControllerDelegate  {
 
     override func textFieldDidEndEditing(_ textField: UITextField) {
         isNickNameWrite = true
         nickNameTextFieldClearButton.isHidden = false
     }
-    
+
     func imagePickerController(_ picker: UIImagePickerController, didFinishPickingMediaWithInfo info: [UIImagePickerController.InfoKey : Any]) {
 
         var newImage : UIImage? = nil // update 할 이미지
@@ -299,4 +295,3 @@ extension LoginProfileViewController: UIImagePickerControllerDelegate, UINavigat
         dismiss(animated: true, completion: nil)
     }
 }
-

--- a/Flicker/Screens/ProfileSetting/ProfileSettingViewController.swift
+++ b/Flicker/Screens/ProfileSetting/ProfileSettingViewController.swift
@@ -253,7 +253,7 @@ final class ProfileSettingViewController: BaseViewController {
             signUpButton.backgroundColor = .mainPink
         }
     }
-//TODO: profileImage가 없을 경우 이미지 값을 SFSymbol에서 받으려고 하는데 그 값조차 옵셔널 값으로 인식함 그래서 일단 강제언래핑 해놓음
+    //TODO: profileImage가 없을 경우 이미지 값을 SFSymbol에서 받으려고 하는데 그 값조차 옵셔널 값으로 인식함 그래서 일단 강제언래핑 해놓음
     @objc private func didTapSignUpButton() {
         self.dismiss(animated: true, completion: nil)
     }

--- a/Flicker/Screens/SignUp/LoginProfileViewController.swift
+++ b/Flicker/Screens/SignUp/LoginProfileViewController.swift
@@ -189,16 +189,6 @@ final class LoginProfileViewController: BaseViewController {
             $0.leading.trailing.equalToSuperview().inset(20)
             $0.height.equalTo(50)
         }
-
-//        logOutButton.snp.makeConstraints {
-//            $0.top.equalTo(signUpButton.snp.bottom).offset(10)
-//            $0.trailing.equalTo(view.snp.centerX).inset(20)
-//        }
-//
-//        signOutButton.snp.makeConstraints {
-//            $0.top.equalTo(signUpButton.snp.bottom).offset(10)
-//            $0.leading.equalTo(view.snp.centerX).offset(20)
-//        }
     }
         override func viewDidAppear(_ animated: Bool) {
             super.viewDidAppear(animated)
@@ -246,11 +236,6 @@ final class LoginProfileViewController: BaseViewController {
     @objc private func didTapClearButton() {
         self.nickNameField.text = ""
     }
-
-//    @objc private func didTapLogOutButton() {
-//        makeRequestAlert(title: "로그아웃 하시겠어요?", message: "", okAction: { _ in self.fireBaseSignOut()
-//        })
-//    }
 }
 
 extension LoginProfileViewController: UIImagePickerControllerDelegate, UINavigationControllerDelegate {

--- a/Flicker/Screens/SignUp/LoginProfileViewController.swift
+++ b/Flicker/Screens/SignUp/LoginProfileViewController.swift
@@ -189,6 +189,16 @@ final class LoginProfileViewController: BaseViewController {
             $0.leading.trailing.equalToSuperview().inset(20)
             $0.height.equalTo(50)
         }
+
+//        logOutButton.snp.makeConstraints {
+//            $0.top.equalTo(signUpButton.snp.bottom).offset(10)
+//            $0.trailing.equalTo(view.snp.centerX).inset(20)
+//        }
+//
+//        signOutButton.snp.makeConstraints {
+//            $0.top.equalTo(signUpButton.snp.bottom).offset(10)
+//            $0.leading.equalTo(view.snp.centerX).offset(20)
+//        }
     }
         override func viewDidAppear(_ animated: Bool) {
             super.viewDidAppear(animated)
@@ -236,6 +246,11 @@ final class LoginProfileViewController: BaseViewController {
     @objc private func didTapClearButton() {
         self.nickNameField.text = ""
     }
+
+//    @objc private func didTapLogOutButton() {
+//        makeRequestAlert(title: "로그아웃 하시겠어요?", message: "", okAction: { _ in self.fireBaseSignOut()
+//        })
+//    }
 }
 
 extension LoginProfileViewController: UIImagePickerControllerDelegate, UINavigationControllerDelegate {

--- a/Flicker/Screens/SignUp/LoginProfileViewController.swift
+++ b/Flicker/Screens/SignUp/LoginProfileViewController.swift
@@ -9,6 +9,7 @@ import UIKit
 
 import SnapKit
 import Then
+import FirebaseAuth
 
 final class LoginProfileViewController: BaseViewController {
 
@@ -52,7 +53,7 @@ final class LoginProfileViewController: BaseViewController {
     private let nickNameLabel = UILabel().makeBasicLabel(labelText: "닉네임", textColor: .black, fontStyle: .title3, fontWeight: .bold)
     private let isArtistLabel = UILabel().makeBasicLabel(labelText: "사진작가로 활동할 예정이신가요?", textColor: .black, fontStyle: .title3, fontWeight: .bold)
     private let afterJoinLabel = UILabel().makeBasicLabel(labelText: "가입 후 마이프로필에서 작가등록을 하실 수 있어요!", textColor: .textSubBlack, fontStyle: .caption1, fontWeight: .medium)
-    
+
     private let nickNameField = UITextField().then {
         let attributes = [
             NSAttributedString.Key.foregroundColor : UIColor.textSubBlack,
@@ -60,7 +61,7 @@ final class LoginProfileViewController: BaseViewController {
         ]
 
         $0.backgroundColor = .clear
-        $0.attributedPlaceholder = NSAttributedString(string: "닉네임을 입력 해 주세요!", attributes: attributes)
+        $0.attributedPlaceholder = NSAttributedString(string: "닉네임을 입력해 주세요!", attributes: attributes)
         $0.autocapitalizationType = .none
         $0.layer.masksToBounds = true
         $0.leftView = UIView(frame: CGRect(x: 0, y: 0, width: 5, height: 0))
@@ -104,12 +105,23 @@ final class LoginProfileViewController: BaseViewController {
         $0.backgroundColor = .loginGray
     }
 
+    private let logOutButton = UIButton().then {
+        $0.setTitle("로그아웃", for: .normal)
+        $0.setTitleColor( .textSubBlack, for: .normal)
+        $0.backgroundColor = .clear
+    }
+
+    private let signOutButton = UIButton().then {
+        $0.setTitle("회원탈퇴", for: .normal)
+        $0.setTitleColor( .textSubBlack, for: .normal)
+        $0.backgroundColor = .clear
+    }
+
     override func render() {
         nickNameField.delegate = self
-
         signUpButton.isEnabled = false
         nickNameTextFieldClearButton.isHidden = true
-        
+
         view.addSubviews(profileImageView, cameraImage ,profileLabelFirst, profileLabelSecond, nickNameLabel, isArtistLabel, afterJoinLabel, nickNameField, artistTrueButton, artistFalseButton, signUpButton, navigationDivider, nickNameTextFieldClearButton, nickNameDivider)
 
 
@@ -182,13 +194,13 @@ final class LoginProfileViewController: BaseViewController {
         artistTrueButton.snp.makeConstraints {
             $0.top.equalTo(afterJoinLabel.snp.bottom).offset(10)
             $0.leading.equalToSuperview().inset(20)
-            $0.width.equalTo(170)
+            $0.trailing.equalTo(view.snp.centerX).inset(25 )
         }
 
         artistFalseButton.snp.makeConstraints {
             $0.top.equalTo(afterJoinLabel.snp.bottom).offset(10)
             $0.trailing.equalToSuperview().inset(20)
-            $0.width.equalTo(170)
+            $0.leading.equalTo(view.snp.centerX).offset(10)
         }
 
         signUpButton.snp.makeConstraints {
@@ -197,12 +209,10 @@ final class LoginProfileViewController: BaseViewController {
             $0.height.equalTo(50)
         }
     }
-        override func viewDidAppear(_ animated: Bool) {
-            super.viewDidAppear(animated)
-        }
 
-        override func setupNavigationBar() {
-            super.setupNavigationBar()
+    override func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
+    }
 
     override func viewWillDisappear(_ animated: Bool) {
         super.viewWillDisappear(animated)
@@ -278,17 +288,16 @@ final class LoginProfileViewController: BaseViewController {
     }
 }
 
-extension LoginProfileViewController: UIImagePickerControllerDelegate, UINavigationControllerDelegate {
+extension LoginProfileViewController: UIImagePickerControllerDelegate, UINavigationControllerDelegate  {
 
     override func textFieldDidEndEditing(_ textField: UITextField) {
         isNickNameWrite = true
         nickNameTextFieldClearButton.isHidden = false
     }
-    
+
     func imagePickerController(_ picker: UIImagePickerController, didFinishPickingMediaWithInfo info: [UIImagePickerController.InfoKey : Any]) {
 
         var newImage : UIImage? = nil // update 할 이미지
-
         if let possibleImage = info[UIImagePickerController.InfoKey.editedImage] as? UIImage {
             newImage = possibleImage    // 수정된 이미지가 있을 경우
         } else if let possibleImage = info[UIImagePickerController.InfoKey.originalImage] as? UIImage {
@@ -299,4 +308,3 @@ extension LoginProfileViewController: UIImagePickerControllerDelegate, UINavigat
         dismiss(animated: true, completion: nil)
     }
 }
-

--- a/Flicker/Screens/SignUp/SignUpViewController.swift
+++ b/Flicker/Screens/SignUp/SignUpViewController.swift
@@ -19,7 +19,7 @@ final class SignUpViewController: BaseViewController {
     
     private let signUpLabel = UILabel().then {
         $0.tintColor = .black
-        $0.font = .preferredFont(forTextStyle: .title3, weight: .semibold)
+        $0.font = .preferredFont(forTextStyle: .body, weight: .semibold)
         $0.numberOfLines = 2
         $0.text = "로그인에 사용될 이메일과 비밀번호를 설정해주세요"
     }
@@ -29,8 +29,7 @@ final class SignUpViewController: BaseViewController {
             NSAttributedString.Key.foregroundColor : UIColor.white,
             NSAttributedString.Key.font : UIFont.systemFont(ofSize: 17, weight: .bold)
         ]
-
-        $0.tag = 0
+        
         $0.backgroundColor = .loginGray
         $0.attributedPlaceholder = NSAttributedString(string: "이메일 주소", attributes: attributes)
         $0.autocapitalizationType = .none
@@ -40,20 +39,16 @@ final class SignUpViewController: BaseViewController {
         $0.leftViewMode = .always
         $0.clipsToBounds = false
         $0.makeShadow(color: .black, opacity: 0.08, offset: CGSize(width: 0, height: 4), radius: 20)
-        $0.autocorrectionType = .no
-
     }
-
-    private let emailValidCheckLabel = UILabel().makeBasicLabel(labelText: "이메일 주소를 확인해 주세요.", textColor: .red, fontStyle: .subheadline, fontWeight: .light)
     
     private let passwordField = UITextField().then {
         let attributes = [
             NSAttributedString.Key.foregroundColor : UIColor.white,
             NSAttributedString.Key.font : UIFont.systemFont(ofSize: 17, weight: .bold)
         ]
-        $0.tag = 1
+        
         $0.backgroundColor = .loginGray
-        $0.attributedPlaceholder = NSAttributedString(string: "비밀번호 (최소 6자 이상)", attributes: attributes)
+        $0.attributedPlaceholder = NSAttributedString(string: "비밀번호", attributes: attributes)
         $0.layer.cornerRadius = 12
         $0.layer.masksToBounds = true
         $0.leftView = UIView(frame: CGRect(x: 0, y: 0, width: 20, height: 0))
@@ -61,35 +56,12 @@ final class SignUpViewController: BaseViewController {
         $0.clipsToBounds = false
         $0.isSecureTextEntry = true
         $0.makeShadow(color: .black, opacity: 0.08, offset: CGSize(width: 0, height: 4), radius: 20)
-        $0.autocorrectionType = .no
     }
-
-    private let passwordValidCheckLabel = UILabel().makeBasicLabel(labelText: "비밀번호는 6자리 이상으로 작성해주세요.", textColor: .red, fontStyle: .subheadline, fontWeight: .light)
-
-    private let passwordSameCheckField = UITextField().then {
-        let attributes = [
-            NSAttributedString.Key.foregroundColor : UIColor.white,
-            NSAttributedString.Key.font : UIFont.systemFont(ofSize: 17, weight: .bold)
-        ]
-        $0.tag = 2
-        $0.backgroundColor = .loginGray
-        $0.attributedPlaceholder = NSAttributedString(string: "비밀번호 확인", attributes: attributes)
-        $0.layer.cornerRadius = 12
-        $0.layer.masksToBounds = true
-        $0.leftView = UIView(frame: CGRect(x: 0, y: 0, width: 20, height: 0))
-        $0.leftViewMode = .always
-        $0.clipsToBounds = false
-        $0.isSecureTextEntry = true
-        $0.makeShadow(color: .black, opacity: 0.08, offset: CGSize(width: 0, height: 4), radius: 20)
-        $0.autocorrectionType = .no
-    }
-
-    private let passwordSameCheckLabel = UILabel().makeBasicLabel(labelText: "비밀번호가 일치하지 않습니다.", textColor: .red, fontStyle: .subheadline, fontWeight: .light)
     
     private lazy var signUpButton = UIButton().then {
         $0.backgroundColor = .loginGray
         $0.setTitleColor(.white, for: .normal)
-        $0.setTitle("다음", for: .normal)
+        $0.setTitle("완료", for: .normal)
         $0.layer.cornerRadius = 20
         $0.addTarget(self, action: #selector(didTapSignUpButton), for: .touchUpInside)
     }
@@ -101,18 +73,10 @@ final class SignUpViewController: BaseViewController {
     override func render() {
         emailField.delegate = self
         passwordField.delegate = self
-        passwordSameCheckField.delegate = self
-
-        emailField.returnKeyType = .done
-        passwordField.returnKeyType = .done
-        passwordSameCheckField.returnKeyType = .done
-
-        emailValidCheckLabel.isHidden = true
-        passwordValidCheckLabel.isHidden = true
-        passwordSameCheckLabel.isHidden = true
         
-        view.addSubviews(emailValidCheckLabel ,signUpTitleLabel, signUpLabel, emailField, passwordField, signUpButton, navigationDivider, passwordSameCheckField, passwordValidCheckLabel, passwordSameCheckLabel)
-
+        view.addSubviews(signUpTitleLabel, signUpLabel, emailField, passwordField, signUpButton, navigationDivider)
+        
+        
         signUpTitleLabel.snp.makeConstraints {
             $0.top.equalTo(view.safeAreaLayoutGuide.snp.top).offset(30)
             $0.leading.equalToSuperview().inset(30)
@@ -129,38 +93,18 @@ final class SignUpViewController: BaseViewController {
             $0.leading.trailing.equalToSuperview().inset(20)
             $0.height.equalTo(60)
         }
-
-        emailValidCheckLabel.snp.makeConstraints {
-            $0.top.equalTo(emailField.snp.bottom).offset(5)
-            $0.leading.equalToSuperview().inset(40)
-        }
-
+        
         passwordField.snp.makeConstraints {
-            $0.top.equalTo(emailField.snp.bottom).offset(45)
+            $0.top.equalTo(emailField.snp.bottom).offset(10)
             $0.leading.trailing.equalToSuperview().inset(20)
             $0.height.equalTo(60)
         }
-
-        passwordValidCheckLabel.snp.makeConstraints {
-            $0.top.equalTo(passwordField.snp.bottom).offset(5)
-            $0.leading.equalToSuperview().inset(40)
-        }
-
-        passwordSameCheckField.snp.makeConstraints {
-            $0.top.equalTo(passwordField.snp.bottom).offset(45)
-            $0.leading.trailing.equalToSuperview().inset(20)
-            $0.height.equalTo(60)
-        }
-
-        passwordSameCheckLabel.snp.makeConstraints {
-            $0.top.equalTo(passwordSameCheckField.snp.bottom).offset(5)
-            $0.leading.equalToSuperview().inset(40)
-        }
+        
         
         signUpButton.snp.makeConstraints {
             $0.bottom.equalTo(view.safeAreaLayoutGuide.snp.bottom).inset(50)
             $0.leading.trailing.equalToSuperview().inset(20)
-            $0.height.equalTo(55)
+            $0.height.equalTo(50)
         }
         
         navigationDivider.snp.makeConstraints {
@@ -181,12 +125,11 @@ final class SignUpViewController: BaseViewController {
         title = "프로필 입력"
         
     }
-    //
+    
     @objc private func didTapSignUpButton() {
         let viewController = LoginProfileViewController()
-        guard let email = emailField.text, emailValidCheck(emailField),
-              let password = passwordField.text, passwordValidCheck(passwordField),
-              let passwordCheck = passwordSameCheckField.text, passwordSameCheck(passwordField, passwordSameCheckField) else {
+        guard let email = emailField.text, !email.isEmpty,
+              let password = passwordField.text, !password.isEmpty else {
             print("Missing field data")
             return
         }
@@ -198,6 +141,7 @@ final class SignUpViewController: BaseViewController {
         self.navigationController?.pushViewController(viewController, animated: true)
         
     }
+    
 }
 
 extension SignUpViewController {

--- a/Flicker/Screens/SignUp/SignUpViewController.swift
+++ b/Flicker/Screens/SignUp/SignUpViewController.swift
@@ -12,6 +12,8 @@ import Then
 
 final class SignUpViewController: BaseViewController {
 
+    private let didTapSignUpEmail = true
+
     private let signUpTitleLabel = UILabel().makeBasicLabel(labelText: "반가워요!", textColor: .black, fontStyle: .largeTitle, fontWeight: .bold)
 
     
@@ -131,21 +133,48 @@ final class SignUpViewController: BaseViewController {
             print("Missing field data")
             return
         }
-        //TODO: email값을 다음 뷰에 넘겨줘 다음 뷰에서 email값과 name값을 파베로 넘겨줘야 함
-        Task { [weak self] in
-            await FirebaseManager.shared.createNewAccount(email: email, password: password)
-            //            await FirebaseManager.shared.storeUserInformation(email: email, name: name)
-            self?.navigationController?.pushViewController(viewController, animated: true)
-        }
+
+        viewController.authEmail = email
+        viewController.authPassword = passwordCheck
+        viewController.isSignUpEmail = self.didTapSignUpEmail
+
+        self.navigationController?.pushViewController(viewController, animated: true)
+        
     }
     
 }
-    extension SignUpViewController {
-        override func textFieldDidEndEditing(_ textField: UITextField) {
-            if !(emailField.text!.isEmpty || passwordField.text!.isEmpty) {
-                signUpButton.backgroundColor = .mainPink
+
+extension SignUpViewController {
+    override func textFieldDidEndEditing(_ textField: UITextField) {
+        //이메일 유효성 검사 후 검사에 통과하면 아무 표시도 하지않고 검사에 통과하지 못한다면 라벨을 통해 이메일을 확인하라는 표시를 해줌
+
+        switch textField.tag {
+        case 0:
+            if !emailValidCheck(emailField) {
+                emailValidCheckLabel.isHidden = false
+
             } else {
-                signUpButton.backgroundColor = .loginGray
+                emailValidCheckLabel.isHidden = true
             }
+        case 1:
+            if !passwordValidCheck(passwordField) {
+                passwordValidCheckLabel.isHidden = false
+
+            } else {
+                passwordValidCheckLabel.isHidden = true
+            }
+        case 2:
+            if !passwordSameCheck(passwordField, passwordSameCheckField) {
+                passwordSameCheckLabel.isHidden = false
+            } else {
+                passwordSameCheckLabel.isHidden = true
+            }
+        default: return
+        }
+
+        if ( emailValidCheck(emailField) && passwordValidCheck(passwordField) && passwordSameCheck(passwordField, passwordSameCheckField)) {
+            signUpButton.backgroundColor = .mainPink
+        } else {
+            signUpButton.backgroundColor = .loginGray
         }
     }

--- a/Flicker/Screens/SignUp/SignUpViewController.swift
+++ b/Flicker/Screens/SignUp/SignUpViewController.swift
@@ -16,20 +16,21 @@ final class SignUpViewController: BaseViewController {
 
     private let signUpTitleLabel = UILabel().makeBasicLabel(labelText: "반가워요!", textColor: .black, fontStyle: .largeTitle, fontWeight: .bold)
 
-    
+
     private let signUpLabel = UILabel().then {
         $0.tintColor = .black
-        $0.font = .preferredFont(forTextStyle: .body, weight: .semibold)
+        $0.font = .preferredFont(forTextStyle: .title3, weight: .semibold)
         $0.numberOfLines = 2
         $0.text = "로그인에 사용될 이메일과 비밀번호를 설정해주세요"
     }
-    
+
     private let emailField = UITextField().then {
         let attributes = [
             NSAttributedString.Key.foregroundColor : UIColor.white,
             NSAttributedString.Key.font : UIFont.systemFont(ofSize: 17, weight: .bold)
         ]
-        
+
+        $0.tag = 0
         $0.backgroundColor = .loginGray
         $0.attributedPlaceholder = NSAttributedString(string: "이메일 주소", attributes: attributes)
         $0.autocapitalizationType = .none
@@ -39,16 +40,20 @@ final class SignUpViewController: BaseViewController {
         $0.leftViewMode = .always
         $0.clipsToBounds = false
         $0.makeShadow(color: .black, opacity: 0.08, offset: CGSize(width: 0, height: 4), radius: 20)
+        $0.autocorrectionType = .no
+
     }
-    
+
+    private let emailValidCheckLabel = UILabel().makeBasicLabel(labelText: "이메일 주소를 확인해 주세요.", textColor: .red, fontStyle: .subheadline, fontWeight: .light)
+
     private let passwordField = UITextField().then {
         let attributes = [
             NSAttributedString.Key.foregroundColor : UIColor.white,
             NSAttributedString.Key.font : UIFont.systemFont(ofSize: 17, weight: .bold)
         ]
-        
+        $0.tag = 1
         $0.backgroundColor = .loginGray
-        $0.attributedPlaceholder = NSAttributedString(string: "비밀번호", attributes: attributes)
+        $0.attributedPlaceholder = NSAttributedString(string: "비밀번호 (최소 6자 이상)", attributes: attributes)
         $0.layer.cornerRadius = 12
         $0.layer.masksToBounds = true
         $0.leftView = UIView(frame: CGRect(x: 0, y: 0, width: 20, height: 0))
@@ -56,80 +61,132 @@ final class SignUpViewController: BaseViewController {
         $0.clipsToBounds = false
         $0.isSecureTextEntry = true
         $0.makeShadow(color: .black, opacity: 0.08, offset: CGSize(width: 0, height: 4), radius: 20)
+        $0.autocorrectionType = .no
     }
-    
+
+    private let passwordValidCheckLabel = UILabel().makeBasicLabel(labelText: "비밀번호는 6자리 이상으로 작성해주세요.", textColor: .red, fontStyle: .subheadline, fontWeight: .light)
+
+    private let passwordSameCheckField = UITextField().then {
+        let attributes = [
+            NSAttributedString.Key.foregroundColor : UIColor.white,
+            NSAttributedString.Key.font : UIFont.systemFont(ofSize: 17, weight: .bold)
+        ]
+        $0.tag = 2
+        $0.backgroundColor = .loginGray
+        $0.attributedPlaceholder = NSAttributedString(string: "비밀번호 확인", attributes: attributes)
+        $0.layer.cornerRadius = 12
+        $0.layer.masksToBounds = true
+        $0.leftView = UIView(frame: CGRect(x: 0, y: 0, width: 20, height: 0))
+        $0.leftViewMode = .always
+        $0.clipsToBounds = false
+        $0.isSecureTextEntry = true
+        $0.makeShadow(color: .black, opacity: 0.08, offset: CGSize(width: 0, height: 4), radius: 20)
+        $0.autocorrectionType = .no
+    }
+
+    private let passwordSameCheckLabel = UILabel().makeBasicLabel(labelText: "비밀번호가 일치하지 않습니다.", textColor: .red, fontStyle: .subheadline, fontWeight: .light)
+
     private lazy var signUpButton = UIButton().then {
         $0.backgroundColor = .loginGray
         $0.setTitleColor(.white, for: .normal)
-        $0.setTitle("완료", for: .normal)
+        $0.setTitle("다음", for: .normal)
         $0.layer.cornerRadius = 20
         $0.addTarget(self, action: #selector(didTapSignUpButton), for: .touchUpInside)
     }
-    
+
     private let navigationDivider = UIView().then {
         $0.backgroundColor = .loginGray
     }
-    
+
     override func render() {
         emailField.delegate = self
         passwordField.delegate = self
-        
-        view.addSubviews(signUpTitleLabel, signUpLabel, emailField, passwordField, signUpButton, navigationDivider)
-        
-        
+        passwordSameCheckField.delegate = self
+
+        emailField.returnKeyType = .done
+        passwordField.returnKeyType = .done
+        passwordSameCheckField.returnKeyType = .done
+
+        emailValidCheckLabel.isHidden = true
+        passwordValidCheckLabel.isHidden = true
+        passwordSameCheckLabel.isHidden = true
+
+        view.addSubviews(emailValidCheckLabel ,signUpTitleLabel, signUpLabel, emailField, passwordField, signUpButton, navigationDivider, passwordSameCheckField, passwordValidCheckLabel, passwordSameCheckLabel)
+
         signUpTitleLabel.snp.makeConstraints {
             $0.top.equalTo(view.safeAreaLayoutGuide.snp.top).offset(30)
             $0.leading.equalToSuperview().inset(30)
         }
-        
+
         signUpLabel.snp.makeConstraints {
             $0.top.equalTo(signUpTitleLabel.snp.bottom).offset(10)
             $0.leading.equalToSuperview().inset(30)
             $0.width.equalTo(250)
         }
-        
+
         emailField.snp.makeConstraints {
             $0.top.equalTo(signUpLabel.snp.bottom).offset(30)
             $0.leading.trailing.equalToSuperview().inset(20)
             $0.height.equalTo(60)
         }
-        
+
+        emailValidCheckLabel.snp.makeConstraints {
+            $0.top.equalTo(emailField.snp.bottom).offset(5)
+            $0.leading.equalToSuperview().inset(40)
+        }
+
         passwordField.snp.makeConstraints {
-            $0.top.equalTo(emailField.snp.bottom).offset(10)
+            $0.top.equalTo(emailField.snp.bottom).offset(45)
             $0.leading.trailing.equalToSuperview().inset(20)
             $0.height.equalTo(60)
         }
-        
-        
+
+        passwordValidCheckLabel.snp.makeConstraints {
+            $0.top.equalTo(passwordField.snp.bottom).offset(5)
+            $0.leading.equalToSuperview().inset(40)
+        }
+
+        passwordSameCheckField.snp.makeConstraints {
+            $0.top.equalTo(passwordField.snp.bottom).offset(45)
+            $0.leading.trailing.equalToSuperview().inset(20)
+            $0.height.equalTo(60)
+        }
+
+        passwordSameCheckLabel.snp.makeConstraints {
+            $0.top.equalTo(passwordSameCheckField.snp.bottom).offset(5)
+            $0.leading.equalToSuperview().inset(40)
+        }
+
         signUpButton.snp.makeConstraints {
             $0.bottom.equalTo(view.safeAreaLayoutGuide.snp.bottom).inset(50)
             $0.leading.trailing.equalToSuperview().inset(20)
-            $0.height.equalTo(50)
+            $0.height.equalTo(55)
         }
-        
+
         navigationDivider.snp.makeConstraints {
             $0.top.equalTo(view.safeAreaLayoutGuide.snp.top)
             $0.leading.trailing.equalToSuperview()
             $0.height.equalTo(2)
         }
     }
-    
+
     override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
         emailField.becomeFirstResponder()
     }
-    
+
     override func setupNavigationBar() {
         super.setupNavigationBar()
-        
+
         title = "프로필 입력"
-        
     }
-    
+    //
     @objc private func didTapSignUpButton() {
+
         let viewController = LoginProfileViewController()
-        guard let email = emailField.text, !email.isEmpty,
-              let password = passwordField.text, !password.isEmpty else {
+        guard let email = emailField.text, emailValidCheck(emailField),
+              let password = passwordField.text, passwordValidCheck(passwordField),
+              let passwordCheck = passwordSameCheckField.text, passwordSameCheck(passwordField, passwordSameCheckField) else {
             print("Missing field data")
             return
         }
@@ -139,15 +196,13 @@ final class SignUpViewController: BaseViewController {
         viewController.isSignUpEmail = self.didTapSignUpEmail
 
         self.navigationController?.pushViewController(viewController, animated: true)
-        
+
     }
-    
 }
 
 extension SignUpViewController {
     override func textFieldDidEndEditing(_ textField: UITextField) {
         //이메일 유효성 검사 후 검사에 통과하면 아무 표시도 하지않고 검사에 통과하지 못한다면 라벨을 통해 이메일을 확인하라는 표시를 해줌
-
         switch textField.tag {
         case 0:
             if !emailValidCheck(emailField) {
@@ -159,7 +214,7 @@ extension SignUpViewController {
         case 1:
             if !passwordValidCheck(passwordField) {
                 passwordValidCheckLabel.isHidden = false
-
+                
             } else {
                 passwordValidCheckLabel.isHidden = true
             }
@@ -178,3 +233,4 @@ extension SignUpViewController {
             signUpButton.backgroundColor = .loginGray
         }
     }
+}

--- a/Flicker/Screens/SignUp/SignUpViewController.swift
+++ b/Flicker/Screens/SignUp/SignUpViewController.swift
@@ -19,7 +19,7 @@ final class SignUpViewController: BaseViewController {
     
     private let signUpLabel = UILabel().then {
         $0.tintColor = .black
-        $0.font = .preferredFont(forTextStyle: .body, weight: .semibold)
+        $0.font = .preferredFont(forTextStyle: .title3, weight: .semibold)
         $0.numberOfLines = 2
         $0.text = "로그인에 사용될 이메일과 비밀번호를 설정해주세요"
     }
@@ -29,7 +29,8 @@ final class SignUpViewController: BaseViewController {
             NSAttributedString.Key.foregroundColor : UIColor.white,
             NSAttributedString.Key.font : UIFont.systemFont(ofSize: 17, weight: .bold)
         ]
-        
+
+        $0.tag = 0
         $0.backgroundColor = .loginGray
         $0.attributedPlaceholder = NSAttributedString(string: "이메일 주소", attributes: attributes)
         $0.autocapitalizationType = .none
@@ -39,16 +40,20 @@ final class SignUpViewController: BaseViewController {
         $0.leftViewMode = .always
         $0.clipsToBounds = false
         $0.makeShadow(color: .black, opacity: 0.08, offset: CGSize(width: 0, height: 4), radius: 20)
+        $0.autocorrectionType = .no
+
     }
+
+    private let emailValidCheckLabel = UILabel().makeBasicLabel(labelText: "이메일 주소를 확인해 주세요.", textColor: .red, fontStyle: .subheadline, fontWeight: .light)
     
     private let passwordField = UITextField().then {
         let attributes = [
             NSAttributedString.Key.foregroundColor : UIColor.white,
             NSAttributedString.Key.font : UIFont.systemFont(ofSize: 17, weight: .bold)
         ]
-        
+        $0.tag = 1
         $0.backgroundColor = .loginGray
-        $0.attributedPlaceholder = NSAttributedString(string: "비밀번호", attributes: attributes)
+        $0.attributedPlaceholder = NSAttributedString(string: "비밀번호 (최소 6자 이상)", attributes: attributes)
         $0.layer.cornerRadius = 12
         $0.layer.masksToBounds = true
         $0.leftView = UIView(frame: CGRect(x: 0, y: 0, width: 20, height: 0))
@@ -56,12 +61,35 @@ final class SignUpViewController: BaseViewController {
         $0.clipsToBounds = false
         $0.isSecureTextEntry = true
         $0.makeShadow(color: .black, opacity: 0.08, offset: CGSize(width: 0, height: 4), radius: 20)
+        $0.autocorrectionType = .no
     }
+
+    private let passwordValidCheckLabel = UILabel().makeBasicLabel(labelText: "비밀번호는 6자리 이상으로 작성해주세요.", textColor: .red, fontStyle: .subheadline, fontWeight: .light)
+
+    private let passwordSameCheckField = UITextField().then {
+        let attributes = [
+            NSAttributedString.Key.foregroundColor : UIColor.white,
+            NSAttributedString.Key.font : UIFont.systemFont(ofSize: 17, weight: .bold)
+        ]
+        $0.tag = 2
+        $0.backgroundColor = .loginGray
+        $0.attributedPlaceholder = NSAttributedString(string: "비밀번호 확인", attributes: attributes)
+        $0.layer.cornerRadius = 12
+        $0.layer.masksToBounds = true
+        $0.leftView = UIView(frame: CGRect(x: 0, y: 0, width: 20, height: 0))
+        $0.leftViewMode = .always
+        $0.clipsToBounds = false
+        $0.isSecureTextEntry = true
+        $0.makeShadow(color: .black, opacity: 0.08, offset: CGSize(width: 0, height: 4), radius: 20)
+        $0.autocorrectionType = .no
+    }
+
+    private let passwordSameCheckLabel = UILabel().makeBasicLabel(labelText: "비밀번호가 일치하지 않습니다.", textColor: .red, fontStyle: .subheadline, fontWeight: .light)
     
     private lazy var signUpButton = UIButton().then {
         $0.backgroundColor = .loginGray
         $0.setTitleColor(.white, for: .normal)
-        $0.setTitle("완료", for: .normal)
+        $0.setTitle("다음", for: .normal)
         $0.layer.cornerRadius = 20
         $0.addTarget(self, action: #selector(didTapSignUpButton), for: .touchUpInside)
     }
@@ -73,10 +101,18 @@ final class SignUpViewController: BaseViewController {
     override func render() {
         emailField.delegate = self
         passwordField.delegate = self
+        passwordSameCheckField.delegate = self
+
+        emailField.returnKeyType = .done
+        passwordField.returnKeyType = .done
+        passwordSameCheckField.returnKeyType = .done
+
+        emailValidCheckLabel.isHidden = true
+        passwordValidCheckLabel.isHidden = true
+        passwordSameCheckLabel.isHidden = true
         
-        view.addSubviews(signUpTitleLabel, signUpLabel, emailField, passwordField, signUpButton, navigationDivider)
-        
-        
+        view.addSubviews(emailValidCheckLabel ,signUpTitleLabel, signUpLabel, emailField, passwordField, signUpButton, navigationDivider, passwordSameCheckField, passwordValidCheckLabel, passwordSameCheckLabel)
+
         signUpTitleLabel.snp.makeConstraints {
             $0.top.equalTo(view.safeAreaLayoutGuide.snp.top).offset(30)
             $0.leading.equalToSuperview().inset(30)
@@ -93,18 +129,38 @@ final class SignUpViewController: BaseViewController {
             $0.leading.trailing.equalToSuperview().inset(20)
             $0.height.equalTo(60)
         }
-        
+
+        emailValidCheckLabel.snp.makeConstraints {
+            $0.top.equalTo(emailField.snp.bottom).offset(5)
+            $0.leading.equalToSuperview().inset(40)
+        }
+
         passwordField.snp.makeConstraints {
-            $0.top.equalTo(emailField.snp.bottom).offset(10)
+            $0.top.equalTo(emailField.snp.bottom).offset(45)
             $0.leading.trailing.equalToSuperview().inset(20)
             $0.height.equalTo(60)
         }
-        
+
+        passwordValidCheckLabel.snp.makeConstraints {
+            $0.top.equalTo(passwordField.snp.bottom).offset(5)
+            $0.leading.equalToSuperview().inset(40)
+        }
+
+        passwordSameCheckField.snp.makeConstraints {
+            $0.top.equalTo(passwordField.snp.bottom).offset(45)
+            $0.leading.trailing.equalToSuperview().inset(20)
+            $0.height.equalTo(60)
+        }
+
+        passwordSameCheckLabel.snp.makeConstraints {
+            $0.top.equalTo(passwordSameCheckField.snp.bottom).offset(5)
+            $0.leading.equalToSuperview().inset(40)
+        }
         
         signUpButton.snp.makeConstraints {
             $0.bottom.equalTo(view.safeAreaLayoutGuide.snp.bottom).inset(50)
             $0.leading.trailing.equalToSuperview().inset(20)
-            $0.height.equalTo(50)
+            $0.height.equalTo(55)
         }
         
         navigationDivider.snp.makeConstraints {
@@ -125,11 +181,12 @@ final class SignUpViewController: BaseViewController {
         title = "프로필 입력"
         
     }
-    
+    //
     @objc private func didTapSignUpButton() {
         let viewController = LoginProfileViewController()
-        guard let email = emailField.text, !email.isEmpty,
-              let password = passwordField.text, !password.isEmpty else {
+        guard let email = emailField.text, emailValidCheck(emailField),
+              let password = passwordField.text, passwordValidCheck(passwordField),
+              let passwordCheck = passwordSameCheckField.text, passwordSameCheck(passwordField, passwordSameCheckField) else {
             print("Missing field data")
             return
         }
@@ -141,7 +198,6 @@ final class SignUpViewController: BaseViewController {
         self.navigationController?.pushViewController(viewController, animated: true)
         
     }
-    
 }
 
 extension SignUpViewController {

--- a/Flicker/Screens/Tabbar/TabbarViewController.swift
+++ b/Flicker/Screens/Tabbar/TabbarViewController.swift
@@ -12,7 +12,8 @@ final class TabbarViewController: UITabBarController {
     private let mainViewController = UINavigationController(rootViewController: MainViewController())
     private let searchViewController = UINavigationController(rootViewController: SearchViewController())
     private let messageViewController = UINavigationController(rootViewController: ChannelsViewController())
-    private let profileViewController = UINavigationController(rootViewController: ProfileViewController())
+    private let profileViewController = UINavigationController(rootViewController: ProfileSettingViewController())
+//    private let profileViewController = UINavigationController(rootViewController: ProfileViewController())
     
     override func viewDidLoad() {
 

--- a/Flicker/Screens/Tabbar/TabbarViewController.swift
+++ b/Flicker/Screens/Tabbar/TabbarViewController.swift
@@ -12,8 +12,7 @@ final class TabbarViewController: UITabBarController {
     private let mainViewController = UINavigationController(rootViewController: MainViewController())
     private let searchViewController = UINavigationController(rootViewController: SearchViewController())
     private let messageViewController = UINavigationController(rootViewController: ChannelsViewController())
-    private let profileViewController = UINavigationController(rootViewController: ProfileSettingViewController())
-//    private let profileViewController = UINavigationController(rootViewController: ProfileViewController())
+    private let profileViewController = UINavigationController(rootViewController: ProfileViewController())
     
     override func viewDidLoad() {
 

--- a/Flicker/Screens/WithDraw/WithDrawViewController.swift
+++ b/Flicker/Screens/WithDraw/WithDrawViewController.swift
@@ -54,19 +54,19 @@ final class WithDrawViewController: BaseViewController {
         
         mainLabel.snp.makeConstraints {
             $0.top.equalTo(navigationDivider.snp.bottom).offset(170)
-            $0.leading.equalToSuperview().inset(30)
+            $0.leading.equalToSuperview().inset(45)
         }
         
         subLabel.snp.makeConstraints {
             $0.top.equalTo(mainLabel.snp.bottom).offset(5)
-            $0.leading.equalToSuperview().inset(30)
+            $0.leading.equalToSuperview().inset(45)
             $0.width.equalTo(220)
             $0.height.equalTo(60)
         }
         
         titleLabel.snp.makeConstraints {
             $0.top.equalTo(subLabel.snp.bottom).offset(40)
-            $0.trailing.equalToSuperview().inset(30)
+            $0.trailing.equalToSuperview().inset(45)
         }
         
         signOutButton.snp.makeConstraints {

--- a/Flicker/Screens/WithDraw/WithDrawViewController.swift
+++ b/Flicker/Screens/WithDraw/WithDrawViewController.swift
@@ -78,7 +78,6 @@ final class WithDrawViewController: BaseViewController {
 
     override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
-        self.reAuthUser()
     }
 
     override func viewWillDisappear(_ animated: Bool) {

--- a/Flicker/Screens/WithDraw/WithDrawViewController.swift
+++ b/Flicker/Screens/WithDraw/WithDrawViewController.swift
@@ -1,0 +1,104 @@
+//
+//  SignOutViewController.swift
+//  Flicker
+//
+//  Created by 김연호 on 2022/11/14.
+//
+
+import UIKit
+
+import SnapKit
+import Then
+import AuthenticationServices
+import Firebase
+import FirebaseAuth
+import FirebaseFirestore
+
+final class WithDrawViewController: BaseViewController {
+
+    private let navigationDivider = UIView().then {
+        $0.backgroundColor = .loginGray
+    }
+
+    private let mainLabel = UILabel().makeBasicLabel(labelText: "고마웠어요!", textColor: .textMainBlack, fontStyle: .largeTitle, fontWeight: .bold)
+
+    private let subLabel = UILabel().makeBasicLabel(labelText: "순간을 기념하고 싶을 때 언제든 다시 찾아주세요!", textColor: .textSubBlack, fontStyle: .title3, fontWeight: .bold).then {
+        $0.numberOfLines = 2
+    }
+
+    private let titleLabel = UILabel().then {
+        $0.font = UIFont(name: "TsukimiRounded-Bold", size: 30)
+        $0.textColor = .mainPink.withAlphaComponent(0.6)
+        $0.textAlignment = .center
+        $0.text = "SHUGGLE"
+    }
+
+    private let signOutButton = UIButton().then {
+        $0.backgroundColor = .mainPink
+        $0.setTitleColor(.white, for: .normal)
+        $0.setTitle("탈퇴하기", for: .normal)
+        $0.layer.cornerRadius = 15
+    }
+
+    override func render() {
+        
+        view.addSubviews(navigationDivider, mainLabel, subLabel, titleLabel, signOutButton)
+
+        signOutButton.addTarget(self, action: #selector(didTapSignInbutton), for: .touchUpInside)
+
+        navigationDivider.snp.makeConstraints {
+            $0.top.equalTo(view.safeAreaLayoutGuide.snp.top)
+            $0.leading.trailing.equalToSuperview()
+            $0.height.equalTo(2)
+        }
+
+        mainLabel.snp.makeConstraints {
+            $0.top.equalTo(navigationDivider.snp.bottom).offset(170)
+            $0.leading.equalToSuperview().inset(30)
+        }
+
+        subLabel.snp.makeConstraints {
+            $0.top.equalTo(mainLabel.snp.bottom).offset(5)
+            $0.leading.equalToSuperview().inset(30)
+            $0.width.equalTo(220)
+            $0.height.equalTo(60)
+        }
+
+        titleLabel.snp.makeConstraints {
+            $0.top.equalTo(subLabel.snp.bottom).offset(40)
+            $0.trailing.equalToSuperview().inset(30)
+        }
+
+        signOutButton.snp.makeConstraints {
+            $0.bottom.equalTo(view.safeAreaLayoutGuide.snp.bottom).inset(50)
+            $0.leading.trailing.equalToSuperview().inset(20)
+            $0.height.equalTo(65)
+        }
+    }
+
+    override func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
+        self.reAuthUser()
+    }
+
+    override func viewWillDisappear(_ animated: Bool) {
+        super.viewWillDisappear(animated)
+        navigationController?.setNavigationBarHidden(true, animated: false)
+    }
+
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        navigationController?.setNavigationBarHidden(true, animated: false)
+    }
+
+    override func setupNavigationBar() {
+        super.setupNavigationBar()
+        title = "회원탈퇴"
+    }
+
+    @objc private func didTapSignInbutton() {
+        makeRequestAlert(title: "정말 탈퇴하시겠어요?", message: "회원님의 가입정보는 즉시 삭제되며, 복구가 불가능합니다.", okAction: { _ in self.fireBasewithDraw()
+        })
+    }
+
+}

--- a/Flicker/Screens/WithDraw/WithDrawViewController.swift
+++ b/Flicker/Screens/WithDraw/WithDrawViewController.swift
@@ -15,90 +15,88 @@ import FirebaseAuth
 import FirebaseFirestore
 
 final class WithDrawViewController: BaseViewController {
-
+    
     private let navigationDivider = UIView().then {
         $0.backgroundColor = .loginGray
     }
-
+    
     private let mainLabel = UILabel().makeBasicLabel(labelText: "고마웠어요!", textColor: .textMainBlack, fontStyle: .largeTitle, fontWeight: .bold)
-
+    
     private let subLabel = UILabel().makeBasicLabel(labelText: "순간을 기념하고 싶을 때 언제든 다시 찾아주세요!", textColor: .textSubBlack, fontStyle: .title3, fontWeight: .bold).then {
         $0.numberOfLines = 2
     }
-
+    
     private let titleLabel = UILabel().then {
         $0.font = UIFont(name: "TsukimiRounded-Bold", size: 30)
         $0.textColor = .mainPink.withAlphaComponent(0.6)
         $0.textAlignment = .center
         $0.text = "SHUGGLE"
     }
-
+    
     private let signOutButton = UIButton().then {
         $0.backgroundColor = .mainPink
         $0.setTitleColor(.white, for: .normal)
         $0.setTitle("탈퇴하기", for: .normal)
         $0.layer.cornerRadius = 15
     }
-
+    
     override func render() {
         
         view.addSubviews(navigationDivider, mainLabel, subLabel, titleLabel, signOutButton)
-
+        
         signOutButton.addTarget(self, action: #selector(didTapSignInbutton), for: .touchUpInside)
-
+        
         navigationDivider.snp.makeConstraints {
             $0.top.equalTo(view.safeAreaLayoutGuide.snp.top)
             $0.leading.trailing.equalToSuperview()
             $0.height.equalTo(2)
         }
-
+        
         mainLabel.snp.makeConstraints {
             $0.top.equalTo(navigationDivider.snp.bottom).offset(170)
             $0.leading.equalToSuperview().inset(30)
         }
-
+        
         subLabel.snp.makeConstraints {
             $0.top.equalTo(mainLabel.snp.bottom).offset(5)
             $0.leading.equalToSuperview().inset(30)
             $0.width.equalTo(220)
             $0.height.equalTo(60)
         }
-
+        
         titleLabel.snp.makeConstraints {
             $0.top.equalTo(subLabel.snp.bottom).offset(40)
             $0.trailing.equalToSuperview().inset(30)
         }
-
+        
         signOutButton.snp.makeConstraints {
             $0.bottom.equalTo(view.safeAreaLayoutGuide.snp.bottom).inset(50)
             $0.leading.trailing.equalToSuperview().inset(20)
             $0.height.equalTo(65)
         }
     }
-
+    
     override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
-        self.reAuthUser()
     }
-
+    
     override func viewWillDisappear(_ animated: Bool) {
         super.viewWillDisappear(animated)
         navigationController?.setNavigationBarHidden(true, animated: false)
     }
-
+    
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
         navigationController?.setNavigationBarHidden(true, animated: false)
     }
-
+    
     override func setupNavigationBar() {
         super.setupNavigationBar()
         title = "회원탈퇴"
     }
-
+    
     @objc private func didTapSignInbutton() {
         makeRequestAlert(title: "정말 탈퇴하시겠어요?", message: "회원님의 가입정보는 즉시 삭제되며, 복구가 불가능합니다.", okAction: { _ in self.fireBasewithDraw()
         })
     }
-
 }

--- a/Flicker/Screens/WithDraw/WithDrawViewController.swift
+++ b/Flicker/Screens/WithDraw/WithDrawViewController.swift
@@ -78,6 +78,7 @@ final class WithDrawViewController: BaseViewController {
 
     override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
+        self.reAuthUser()
     }
 
     override func viewWillDisappear(_ animated: Bool) {

--- a/Flicker/Screens/WithDraw/WithDrawViewController.swift~refs/remotes/origin/Feat/38-SignOutView
+++ b/Flicker/Screens/WithDraw/WithDrawViewController.swift~refs/remotes/origin/Feat/38-SignOutView
@@ -1,0 +1,103 @@
+//
+//  SignOutViewController.swift
+//  Flicker
+//
+//  Created by 김연호 on 2022/11/14.
+//
+
+import UIKit
+
+import SnapKit
+import Then
+import AuthenticationServices
+import Firebase
+import FirebaseAuth
+import FirebaseFirestore
+
+final class WithDrawViewController: BaseViewController {
+
+    private let navigationDivider = UIView().then {
+        $0.backgroundColor = .loginGray
+    }
+
+    private let mainLabel = UILabel().makeBasicLabel(labelText: "고마웠어요!", textColor: .textMainBlack, fontStyle: .largeTitle, fontWeight: .bold)
+
+    private let subLabel = UILabel().makeBasicLabel(labelText: "순간을 기념하고 싶을 때 언제든 다시 찾아주세요!", textColor: .textSubBlack, fontStyle: .title3, fontWeight: .bold).then {
+        $0.numberOfLines = 2
+    }
+
+    private let titleLabel = UILabel().then {
+        $0.font = UIFont(name: "TsukimiRounded-Bold", size: 30)
+        $0.textColor = .mainPink.withAlphaComponent(0.6)
+        $0.textAlignment = .center
+        $0.text = "SHUGGLE"
+    }
+
+    private let signOutButton = UIButton().then {
+        $0.backgroundColor = .mainPink
+        $0.setTitleColor(.white, for: .normal)
+        $0.setTitle("탈퇴하기", for: .normal)
+        $0.layer.cornerRadius = 15
+    }
+
+    override func render() {
+        
+        view.addSubviews(navigationDivider, mainLabel, subLabel, titleLabel, signOutButton)
+
+        signOutButton.addTarget(self, action: #selector(didTapSignInbutton), for: .touchUpInside)
+
+        navigationDivider.snp.makeConstraints {
+            $0.top.equalTo(view.safeAreaLayoutGuide.snp.top)
+            $0.leading.trailing.equalToSuperview()
+            $0.height.equalTo(2)
+        }
+
+        mainLabel.snp.makeConstraints {
+            $0.top.equalTo(navigationDivider.snp.bottom).offset(170)
+            $0.leading.equalToSuperview().inset(30)
+        }
+
+        subLabel.snp.makeConstraints {
+            $0.top.equalTo(mainLabel.snp.bottom).offset(5)
+            $0.leading.equalToSuperview().inset(30)
+            $0.width.equalTo(220)
+            $0.height.equalTo(60)
+        }
+
+        titleLabel.snp.makeConstraints {
+            $0.top.equalTo(subLabel.snp.bottom).offset(40)
+            $0.trailing.equalToSuperview().inset(30)
+        }
+
+        signOutButton.snp.makeConstraints {
+            $0.bottom.equalTo(view.safeAreaLayoutGuide.snp.bottom).inset(50)
+            $0.leading.trailing.equalToSuperview().inset(20)
+            $0.height.equalTo(65)
+        }
+    }
+
+    override func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
+    }
+
+    override func viewWillDisappear(_ animated: Bool) {
+        super.viewWillDisappear(animated)
+        navigationController?.setNavigationBarHidden(true, animated: false)
+    }
+
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        navigationController?.setNavigationBarHidden(true, animated: false)
+    }
+
+    override func setupNavigationBar() {
+        super.setupNavigationBar()
+        title = "회원탈퇴"
+    }
+
+    @objc private func didTapSignInbutton() {
+        makeRequestAlert(title: "정말 탈퇴하시겠어요?", message: "회원님의 가입정보는 즉시 삭제되며, 복구가 불가능합니다.", okAction: { _ in self.fireBasewithDraw()
+        })
+    }
+
+}


### PR DESCRIPTION
## 🌁 배경
- 회원가입 및 로그인, 로그아웃 과정에 필요한 기능 및 버그들을 수정 및 추가 했습니다.

## 👩‍💻 작업 내용 (Content)

현재 뷰들끼리 데이터를 넘길 때 이전 화면에서 입력이 끝난 데이터에 대해서 값을 넘기게 되어 직접 넘기는 식으로 구현을 했습니다.

다만 로그인에 대한 재인증 시 이메일인증과 애플로그인 인증에 대한 분기처리를 추가해야하며,

애플 로그인 인증은 맨 처음 LoginVC에서 생성된 난수값 nonce와 idToken값을 그대로 가져와서 로그인을 한 사람이면

그냥 넘어가도록 우선은 구현 했는데 이렇게 짜는건 제 생각엔 아닌 것  같다고 생각이 듭니다. 이때 재인증이 아닌 애플 로그인은 재 로그인식으로 해도 괜찮지 않을까 싶은 생각입니다.

우선 appleLoginManager에 로그인 관련 함수들을 모아놓고 shared를 통해 싱글톤으로 다 관리할 수 있도록 코드르 바꿔볼 예정입니다. 



- [x] 이메일 유효성 검사 추가
- [x] 키보드에 완료버튼 추가
- [x] 비밀번호 확인 텍스트필드 추가
- [x] 버튼 텍스트 수정
- [x] 버튼 한번 탭
- [x] 디자인 수정
- [x] 맞춤법 수정
- [x] 프로필 설정뷰에서 이미지 넣으면 카메라 로고 남는 현상 해결
- [x] 애플로그인 및 이메일 로그인에 따른 서버에 넘기는 값 다르게 처리
- [x] 애플 로그인 및 이메일 로그인에 따라 재인증 처리 함수
- [x] 회원탈퇴 뷰 및 로그아웃 뷰 생성 및 기능 개발
- [x] 회원가입 함수를 닉네임 및 프로필 이미지까지 설정 하는 뷰에서 회원가입 성공 후 서버로 넘기도록 로직 변경

## 📱 스크린샷
- 화면 전환이나 인터렉션이 있는 경우엔 GIF, 정적인 화면이라면 스크린샷을 이용합니다.

<p align="left">
  <img width="250" alt="스크린샷1" src="https://user-images.githubusercontent.com/81131715/202324149-a3045125-3e35-4ccf-9e79-b24d13214721.gif">
  <img width="250" alt="스크린샷2" src="https://user-images.githubusercontent.com/81131715/202324162-05357c1c-3aac-4081-9046-87a7e2f161f2.gif">
</p>


## ✅ 테스트방법
- InputPasswordViewController에 있는 didTapSignInButton내부에 reAuthUser()메소드를 사용하시면 이메일 재인증 처리가 되며 이는 비밀번호를 입력하고 비밀번호가 일치해야 넘어갑니다.
- appleLoginReAuthUser()메소드를 사용하시면 애플로그인 재인증으로 되어 비밀번호 입력 없이 그냥 넘어갑니다. 

## 📣 PR & Issues
- closed #37 
- closed #38 
- closed #42 
- closed #43

## 📬 참고문서, 레퍼런스
- https://firebase.google.com/docs/auth/ios/apple#swift_6

