### PR TITLE
:lipstick: 다크모드를 미지원으로 고정합니다.

### DIFF
--- a/Flicker/Global/Supports/Info.plist
+++ b/Flicker/Global/Supports/Info.plist
@@ -2,6 +2,8 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>UIUserInterfaceStyle</key>
+	<string>Light</string>
 	<key>UIAppFonts</key>
 	<array>
 		<string>TsukimiRounded-Bold.ttf</string>


### PR DESCRIPTION
## 🌁 배경
- 다크모드에 대한 색이 정해지지 않고 현재 다크모드를 고려하여 색을 지정하는 것에 대한 테스크보다 다른 부분이 크다고 생각합니다.
   그래서 위와 같은 이유로 우선은 사용자의 휴대폰이 다크모드여도 앱의 모드는 라이트모드로 고정시켰습니다.

## 👩‍💻 작업 내용 (Content)
- info.plist에 모드를 라이트모드로 고정시켰습니다.
- 
## 📱 스크린샷

<p align="center">
  <img width="300" alt="스크린샷1" src="https://user-images.githubusercontent.com/81131715/202426444-2a69be98-ba4a-436b-9e42-29dfc1794439.gif">
</p>


## ✅ 테스트방법
- PR리뷰어가 변경사항을 확인할 수 있는 방법을 서술합니다.

## 📣 PR & Issues
- 현재 작성 중인 Pull Request와 관련된 PR과 Issues가 있다면 나열합니다.
- closed #56 

## 📬 참고문서, 레퍼런스
- 작업을 하면서 참고한 문서 및 레퍼런스를 작성합니다.
