### PR TITLE
✨ 비밀번호 재설정 기능 추가했습니다.

### DIFF
--- a/Flicker.xcodeproj/project.pbxproj
+++ b/Flicker.xcodeproj/project.pbxproj
@@ -11,6 +11,7 @@
 		1032FFA52910C03D00AE3363 /* TsukimiRounded-Bold.ttf in Resources */ = {isa = PBXBuildFile; fileRef = 1032FFA42910C03D00AE3363 /* TsukimiRounded-Bold.ttf */; };
 		1032FFA72911EE6400AE3363 /* LoginProfileViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1032FFA62911EE6400AE3363 /* LoginProfileViewController.swift */; };
 		103EB1FC29224F2600E11A2A /* WithDrawViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 103EB1FB29224F2600E11A2A /* WithDrawViewController.swift */; };
+		107841FF29267C34004849FC /* PopUpViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 107841FE29267C34004849FC /* PopUpViewController.swift */; };
 		108561112923EAB00083E156 /* ProfileSettingViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 108561102923EAB00083E156 /* ProfileSettingViewController.swift */; };
 		108561162924FBFD0083E156 /* InputPasswordViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 108561152924FBFD0083E156 /* InputPasswordViewController.swift */; };
 		10FE6B6029064FE60064201F /* FirebaseAuth in Frameworks */ = {isa = PBXBuildFile; productRef = 10FE6B5F29064FE60064201F /* FirebaseAuth */; };
@@ -102,6 +103,7 @@
 		1032FFA42910C03D00AE3363 /* TsukimiRounded-Bold.ttf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "TsukimiRounded-Bold.ttf"; sourceTree = "<group>"; };
 		1032FFA62911EE6400AE3363 /* LoginProfileViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginProfileViewController.swift; sourceTree = "<group>"; };
 		103EB1FB29224F2600E11A2A /* WithDrawViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WithDrawViewController.swift; sourceTree = "<group>"; };
+		107841FE29267C34004849FC /* PopUpViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PopUpViewController.swift; sourceTree = "<group>"; };
 		108561102923EAB00083E156 /* ProfileSettingViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfileSettingViewController.swift; sourceTree = "<group>"; };
 		108561152924FBFD0083E156 /* InputPasswordViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InputPasswordViewController.swift; sourceTree = "<group>"; };
 		58118D38291132FB00F08D35 /* ArtistRegisterViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ArtistRegisterViewController.swift; sourceTree = "<group>"; };
@@ -208,6 +210,14 @@
 				103EB1FB29224F2600E11A2A /* WithDrawViewController.swift */,
 			);
 			path = WithDraw;
+			sourceTree = "<group>";
+		};
+		107841FD29267C1E004849FC /* New Group */ = {
+			isa = PBXGroup;
+			children = (
+				107841FE29267C34004849FC /* PopUpViewController.swift */,
+			);
+			path = "New Group";
 			sourceTree = "<group>";
 		};
 		1085610F2923EA6D0083E156 /* ProfileSetting */ = {
@@ -543,6 +553,7 @@
 		CBDC04282906123700C6CF30 /* Login */ = {
 			isa = PBXGroup;
 			children = (
+				107841FD29267C1E004849FC /* New Group */,
 				CBDC042B2906125A00C6CF30 /* LoginViewController.swift */,
 			);
 			path = Login;
@@ -749,6 +760,7 @@
 				CB5BF4782919E10700A3E112 /* ChatSendView.swift in Sources */,
 				5833A779291A66FF0077855F /* RegisterAddPhotosCollectionViewCell.swift in Sources */,
 				CBDC03F729060F3B00C6CF30 /* BaseTableViewCell.swift in Sources */,
+				107841FF29267C34004849FC /* PopUpViewController.swift in Sources */,
 				CBDC043A2906143200C6CF30 /* TabbarViewController.swift in Sources */,
 				CB5BF4842919E1A800A3E112 /* SendButton.swift in Sources */,
 				CB5BF4762919E10700A3E112 /* MyChatTableViewCell.swift in Sources */,

--- a/Flicker.xcodeproj/project.pbxproj
+++ b/Flicker.xcodeproj/project.pbxproj
@@ -212,12 +212,12 @@
 			path = WithDraw;
 			sourceTree = "<group>";
 		};
-		107841FD29267C1E004849FC /* New Group */ = {
+		107841FD29267C1E004849FC /* ResetPassword */ = {
 			isa = PBXGroup;
 			children = (
 				107841FE29267C34004849FC /* PopUpViewController.swift */,
 			);
-			path = "New Group";
+			path = ResetPassword;
 			sourceTree = "<group>";
 		};
 		1085610F2923EA6D0083E156 /* ProfileSetting */ = {
@@ -553,7 +553,7 @@
 		CBDC04282906123700C6CF30 /* Login */ = {
 			isa = PBXGroup;
 			children = (
-				107841FD29267C1E004849FC /* New Group */,
+				107841FD29267C1E004849FC /* ResetPassword */,
 				CBDC042B2906125A00C6CF30 /* LoginViewController.swift */,
 			);
 			path = Login;

--- a/Flicker/Screens/Login/LoginViewController.swift
+++ b/Flicker/Screens/Login/LoginViewController.swift
@@ -19,7 +19,6 @@ final class LogInViewController: BaseViewController {
 
     static let shared = LogInViewController()
     
-    var failSendEmail: Bool = false
     var currentNonce: String?
     var currentAppleIdToken: String?
 

--- a/Flicker/Screens/Login/New Group/PopUpViewController.swift
+++ b/Flicker/Screens/Login/New Group/PopUpViewController.swift
@@ -1,0 +1,169 @@
+//
+//  PopUpViewController.swift
+//  Flicker
+//
+//  Created by 김연호 on 2022/11/17.
+//
+
+import UIKit
+
+import SnapKit
+import Then
+import AuthenticationServices
+import Firebase
+import FirebaseAuth
+import FirebaseFirestore
+
+final class PopUpViewController: BaseViewController  {
+
+   private var isFailSendEmail = false
+
+    private let popUpView = UIView().then {
+        $0.clipsToBounds = true
+        $0.backgroundColor = .white
+        $0.layer.cornerRadius = 12
+    }
+
+    private let mainLabel = UILabel().makeBasicLabel(labelText: "이메일을 입력하세요", textColor: .textMainBlack, fontStyle: .headline, fontWeight: .bold)
+
+    private let subLabel = UILabel().makeBasicLabel(labelText: "이메일을 통해 비밀번호 재설정을 할 수 있어요!", textColor: .textMainBlack, fontStyle: .caption1, fontWeight: .bold)
+
+    private let emailField = UITextField().then {
+        let attributes = [
+            NSAttributedString.Key.foregroundColor : UIColor.white,
+            NSAttributedString.Key.font : UIFont.systemFont(ofSize: 17, weight: .bold)
+        ]
+        $0.autocorrectionType = .no
+        $0.backgroundColor = .loginGray
+        $0.attributedPlaceholder = NSAttributedString(string: "이메일 주소", attributes: attributes)
+        $0.autocapitalizationType = .none
+        $0.layer.cornerRadius = 12
+        $0.layer.masksToBounds = true
+        $0.leftView = UIView(frame: CGRect(x: 0, y: 0, width: 10, height: 0))
+        $0.leftViewMode = .always
+        $0.clipsToBounds = false
+        $0.makeShadow(color: .black, opacity: 0.08, offset: CGSize(width: 0, height: 4), radius: 20)
+    }
+
+    private let emailValidCheckLabel = UILabel().makeBasicLabel(labelText: "이메일 주소를 확인해 주세요.", textColor: .red, fontStyle: .subheadline, fontWeight: .light)
+
+    private let sendEmailButton = UIButton().then {
+        $0.titleLabel?.font = .preferredFont(forTextStyle: .caption1)
+        $0.backgroundColor = .gray
+        $0.setTitleColor(.white, for: .normal)
+        $0.setTitle("보내기", for: .normal)
+        $0.layer.cornerRadius = 12
+    }
+
+    private let cancleButton = UIButton().then {
+        $0.titleLabel?.font = .preferredFont(forTextStyle: .caption1)
+        $0.backgroundColor = .mainPink
+        $0.setTitleColor(.white, for: .normal)
+        $0.setTitle("나가기", for: .normal)
+        $0.layer.cornerRadius = 12
+    }
+
+
+    override func render() {
+
+        view.addSubview(popUpView)
+
+        emailField.delegate = self
+
+        popUpView.addSubviews(mainLabel, subLabel, emailField, emailValidCheckLabel ,sendEmailButton, cancleButton)
+
+        cancleButton.addTarget(self, action: #selector(didTapCancleButton), for: .touchUpInside)
+        sendEmailButton.addTarget(self, action: #selector(didTapSendEmailButton), for: .touchUpInside)
+
+        popUpView.snp.makeConstraints {
+            $0.center.equalToSuperview()
+            $0.width.equalTo(UIScreen.main.bounds.width * 0.75)
+            $0.height.equalTo(UIScreen.main.bounds.height * 0.3)
+        }
+
+        mainLabel.snp.makeConstraints {
+            $0.top.equalTo(popUpView.snp.top).offset(45)
+            $0.leading.trailing.equalToSuperview().inset(30)
+            $0.bottom.equalTo(popUpView.snp.top).offset(85)
+        }
+
+        subLabel.snp.makeConstraints {
+            $0.top.equalTo(mainLabel.snp.bottom)
+            $0.leading.trailing.equalToSuperview().inset(30)
+            $0.height.equalTo(30)
+        }
+
+        emailField.snp.makeConstraints {
+            $0.top.equalTo(subLabel.snp.bottom).offset(10)
+            $0.leading.trailing.equalToSuperview().inset(30)
+            $0.height.equalTo(60)
+        }
+
+        emailValidCheckLabel.snp.makeConstraints {
+            $0.top.equalTo(emailField.snp.bottom).offset(5)
+            $0.leading.equalToSuperview().inset(40)
+        }
+        
+        sendEmailButton.snp.makeConstraints {
+            $0.top.equalTo(emailField.snp.bottom).offset(25)
+            $0.bottom.equalTo(popUpView.snp.bottom).inset(30)
+            $0.leading.equalToSuperview().inset(30)
+            $0.trailing.equalTo(emailField.snp.centerX).offset(-10)
+        }
+
+        cancleButton.snp.makeConstraints {
+            $0.top.equalTo(emailField.snp.bottom).offset(25)
+            $0.bottom.equalTo(popUpView.snp.bottom).inset(30)
+            $0.leading.equalTo(emailField.snp.centerX).offset(10)
+            $0.trailing.equalToSuperview().inset(30)
+
+        }
+    }
+
+    override func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
+    }
+
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        view.backgroundColor = UIColor.gray.withAlphaComponent(0.8)
+        emailValidCheckLabel.isHidden = true
+        sendEmailButton.isEnabled = false
+    }
+
+    @objc func didTapSendEmailButton() {
+
+        if emailValidCheck(emailField) {
+            Auth.auth().sendPasswordReset(withEmail: emailField.text ?? "" ) {(error) in
+                if error != nil {
+                    self.makeAlert(title: "이메일보내기에 실패했습니다.", message: "이메일을 확인 해 주세요")
+                    print("Fail to send")
+                } else {
+                    self.sendEmailButton.isEnabled = false
+                    self.dismiss(animated: true)
+                    print("send email")
+                }
+            }
+        }
+    }
+
+    @objc func didTapCancleButton() {
+        dismiss(animated: true)
+    }
+}
+
+extension PopUpViewController {
+
+    func textFieldDidChangeSelection(_ textField: UITextField) {
+        if emailValidCheck(emailField) {
+            emailValidCheckLabel.isHidden = true
+            sendEmailButton.isEnabled = true
+            sendEmailButton.backgroundColor = .mainPink
+        } else {
+            emailValidCheckLabel.isHidden = false
+            sendEmailButton.isEnabled = false
+            sendEmailButton.backgroundColor = .gray
+        }
+    }
+
+}

--- a/Flicker/Screens/Login/ResetPassword/PopUpViewController.swift
+++ b/Flicker/Screens/Login/ResetPassword/PopUpViewController.swift
@@ -44,7 +44,7 @@ final class PopUpViewController: BaseViewController  {
 
     private let sendEmailButton = UIButton().then {
         $0.titleLabel?.font = .preferredFont(forTextStyle: .caption1)
-        $0.backgroundColor = .gray
+        $0.backgroundColor = .systemGray
         $0.setTitleColor(.white, for: .normal)
         $0.setTitle("보내기", for: .normal)
         $0.layer.cornerRadius = 12
@@ -52,7 +52,7 @@ final class PopUpViewController: BaseViewController  {
 
     private let cancleButton = UIButton().then {
         $0.titleLabel?.font = .preferredFont(forTextStyle: .caption1)
-        $0.backgroundColor = .gray
+        $0.backgroundColor = .systemGray2
         $0.setTitleColor(.white, for: .normal)
         $0.setTitle("나가기", for: .normal)
         $0.layer.cornerRadius = 12
@@ -73,11 +73,11 @@ final class PopUpViewController: BaseViewController  {
         popUpView.snp.makeConstraints {
             $0.center.equalToSuperview()
             $0.width.equalTo(UIScreen.main.bounds.width * 0.75)
-            $0.height.equalTo(UIScreen.main.bounds.height * 0.45)
+            $0.height.equalTo(UIScreen.main.bounds.height * 0.35)
         }
 
         mainLabel.snp.makeConstraints {
-            $0.top.equalTo(popUpView.snp.top).offset(100)
+            $0.top.equalTo(popUpView.snp.top).offset(45)
             $0.leading.trailing.equalToSuperview().inset(30)
             $0.height.equalTo(40)
         }

--- a/Flicker/Screens/Login/ResetPassword/PopUpViewController.swift
+++ b/Flicker/Screens/Login/ResetPassword/PopUpViewController.swift
@@ -52,7 +52,7 @@ final class PopUpViewController: BaseViewController  {
 
     private let cancleButton = UIButton().then {
         $0.titleLabel?.font = .preferredFont(forTextStyle: .caption1)
-        $0.backgroundColor = .mainPink
+        $0.backgroundColor = .gray
         $0.setTitleColor(.white, for: .normal)
         $0.setTitle("나가기", for: .normal)
         $0.layer.cornerRadius = 12
@@ -73,13 +73,13 @@ final class PopUpViewController: BaseViewController  {
         popUpView.snp.makeConstraints {
             $0.center.equalToSuperview()
             $0.width.equalTo(UIScreen.main.bounds.width * 0.75)
-            $0.height.equalTo(UIScreen.main.bounds.height * 0.3)
+            $0.height.equalTo(UIScreen.main.bounds.height * 0.45)
         }
 
         mainLabel.snp.makeConstraints {
-            $0.top.equalTo(popUpView.snp.top).offset(45)
+            $0.top.equalTo(popUpView.snp.top).offset(100)
             $0.leading.trailing.equalToSuperview().inset(30)
-            $0.bottom.equalTo(popUpView.snp.top).offset(85)
+            $0.height.equalTo(40)
         }
 
         subLabel.snp.makeConstraints {
@@ -89,7 +89,7 @@ final class PopUpViewController: BaseViewController  {
         }
 
         emailField.snp.makeConstraints {
-            $0.top.equalTo(subLabel.snp.bottom).offset(10)
+            $0.top.equalTo(subLabel.snp.bottom).offset(20)
             $0.leading.trailing.equalToSuperview().inset(30)
             $0.height.equalTo(60)
         }
@@ -100,16 +100,16 @@ final class PopUpViewController: BaseViewController  {
         }
         
         sendEmailButton.snp.makeConstraints {
-            $0.top.equalTo(emailField.snp.bottom).offset(25)
-            $0.bottom.equalTo(popUpView.snp.bottom).inset(30)
+            $0.top.equalTo(emailField.snp.bottom).offset(35)
+            $0.height.equalTo(50)
             $0.leading.equalToSuperview().inset(30)
-            $0.trailing.equalTo(emailField.snp.centerX).offset(-10)
+            $0.trailing.equalTo(emailField.snp.centerX).offset(-5)
         }
 
         cancleButton.snp.makeConstraints {
-            $0.top.equalTo(emailField.snp.bottom).offset(25)
-            $0.bottom.equalTo(popUpView.snp.bottom).inset(30)
-            $0.leading.equalTo(emailField.snp.centerX).offset(10)
+            $0.top.equalTo(emailField.snp.bottom).offset(35)
+            $0.height.equalTo(50)
+            $0.leading.equalTo(emailField.snp.centerX).offset(5)
             $0.trailing.equalToSuperview().inset(30)
 
         }
@@ -129,7 +129,7 @@ final class PopUpViewController: BaseViewController  {
     @objc func didTapSendEmailButton() {
 
         if emailValidCheck(emailField) {
-            Auth.auth().sendPasswordReset(withEmail: emailField.text ?? "" ) {(error) in
+            Auth.auth().sendPasswordReset(withEmail: emailField.text ?? "" ) { error in
                 if error != nil {
                     self.makeAlert(title: "이메일보내기에 실패했습니다.", message: "이메일을 확인 해 주세요")
                     print("Fail to send")

--- a/Flicker/Screens/Login/ResetPassword/PopUpViewController.swift
+++ b/Flicker/Screens/Login/ResetPassword/PopUpViewController.swift
@@ -9,14 +9,9 @@ import UIKit
 
 import SnapKit
 import Then
-import AuthenticationServices
-import Firebase
 import FirebaseAuth
-import FirebaseFirestore
 
 final class PopUpViewController: BaseViewController  {
-
-   private var isFailSendEmail = false
 
     private let popUpView = UIView().then {
         $0.clipsToBounds = true

--- a/Flicker/Screens/Profile/ProfileViewController.swift
+++ b/Flicker/Screens/Profile/ProfileViewController.swift
@@ -36,15 +36,18 @@ final class ProfileViewController: BaseViewController {
     override func render() {
         view.backgroundColor = .systemGray6
         view.addSubviews(tableView, profileHeader)
-        tableView.snp.makeConstraints {
-            $0.leading.trailing.equalToSuperview()
-            $0.top.bottom.equalTo(view.safeAreaLayoutGuide)
-        }
+
         profileHeader.snp.makeConstraints {
             $0.leading.trailing.equalToSuperview()
             $0.top.equalTo(tableView.snp.top)
             $0.height.equalTo(180)
         }
+
+        tableView.snp.makeConstraints {
+            $0.leading.trailing.equalToSuperview()
+            $0.top.bottom.equalTo(view.safeAreaLayoutGuide)
+        }
+
         tableView.tableHeaderView = profileHeader
     }
 

--- a/Flicker/Screens/ProfileSetting/InputPassword/InputPasswordViewController.swift
+++ b/Flicker/Screens/ProfileSetting/InputPassword/InputPasswordViewController.swift
@@ -111,8 +111,8 @@ final class InputPasswordViewController: BaseViewController {
         //TODO: -
         // 애플재인증과 이메일 재인증을 분기처리하기 위해 서버에 이메일,애플로그인 구별을 하던
         // 코어데이터를 활용해서 하든 이메일로그인 인지 애플로그인 인지 식별을 해야함
-//        reAuthUser()
-        appleLoginReAuthUser()
+        reAuthUser()
+//        appleLoginReAuthUser()
     }
     //사용자 재인증 함수, 이메일은 파베에서 가져오고 비밀번호는 사용자가 입력 한 후, 비밀번호가 틀릴 시 재입력요구, 성공하면 ProfileSettingView로 넘어감
     private func reAuthUser() {

--- a/Flicker/Screens/ProfileSetting/InputPassword/InputPasswordViewController.swift
+++ b/Flicker/Screens/ProfileSetting/InputPassword/InputPasswordViewController.swift
@@ -52,7 +52,7 @@ final class InputPasswordViewController: BaseViewController {
 
         view.addSubviews(navigationDivider, mainLabel, firstSubLabel, secondSubLabel, passwordField,certifiedButton)
 
-        certifiedButton.addTarget(self, action: #selector(didTapSignInbutton), for: .touchUpInside)
+        certifiedButton.addTarget(self, action: #selector(didTapReAuthButton), for: .touchUpInside)
 
         navigationDivider.snp.makeConstraints {
             $0.top.equalTo(view.safeAreaLayoutGuide.snp.top)
@@ -107,12 +107,12 @@ final class InputPasswordViewController: BaseViewController {
         title = "정보관리"
     }
 
-    @objc private func didTapSignInbutton() {
+    @objc private func didTapReAuthButton() {
         //TODO: -
         // 애플재인증과 이메일 재인증을 분기처리하기 위해 서버에 이메일,애플로그인 구별을 하던
         // 코어데이터를 활용해서 하든 이메일로그인 인지 애플로그인 인지 식별을 해야함
         reAuthUser()
-//        appleLoginReAuthUser()
+        //        appleLoginReAuthUser()
     }
     //사용자 재인증 함수, 이메일은 파베에서 가져오고 비밀번호는 사용자가 입력 한 후, 비밀번호가 틀릴 시 재입력요구, 성공하면 ProfileSettingView로 넘어감
     private func reAuthUser() {
@@ -126,11 +126,8 @@ final class InputPasswordViewController: BaseViewController {
                 print(error)
                 self.makeAlert(title: "비밀번호를 확인해주세요", message: "")
             } else {
-                Task{ [weak self] in
-//                    self?.dismiss(animated:true, completion:nil )
-                    let viewController = ProfileSettingViewController()
-                    self?.navigationController?.pushViewController(viewController, animated: true)
-                }
+                let viewController = ProfileSettingViewController()
+                self.navigationController?.pushViewController(viewController, animated: true)
             }
         }
     }
@@ -138,9 +135,9 @@ final class InputPasswordViewController: BaseViewController {
     private func appleLoginReAuthUser() {
         // Initialize a fresh Apple credential with Firebase.
         let credential = OAuthProvider.credential(
-          withProviderID: "apple.com",
-          idToken: LogInViewController.shared.currentAppleIdToken ?? "",
-          rawNonce: LogInViewController.shared.currentNonce
+            withProviderID: "apple.com",
+            idToken: LogInViewController.shared.currentAppleIdToken ?? "",
+            rawNonce: LogInViewController.shared.currentNonce
         )
         // Reauthenticate current Apple user with fresh Apple credential.
         Auth.auth().currentUser?.reauthenticate(with: credential) { (authResult, error) in


### PR DESCRIPTION
## 🌁 배경
- 둘러보기 기능을 삭제하며, 그 빈공간에 무엇을 채워야 하나 고민을 했습니다.

- 생각해보니 비밀번호 찾기 기능자체가 없으면 앱스토어에서 통과가 어려울 것이라는 저의 생각으로 파이어베이스 로그인에 비밀번호 재설정기능을 추가하게 되었습니다.


## 👩‍💻 작업 내용 (Content)
- 뒷 배경이 불투명한 VC로 팝업처럼 보이는 뷰를 추가하여 이메일을 입력하도록 작업했습니다.

- 이메일을 입력하고 올바른 이메일일 경우 메일이 보내지며, 입력한 이메일에서 비밀번호 재설정을 할 수 있는 링크를 받습니다.

- 이 후 링크를 통해 재설정한 비밀번호로 다시 이용이 가능합니다.

- 화면녹화 동영상입니다 죄송함둥

- 로그인 관련 작업을 하면서 얼럿이 뜨는데 화면이 넘어가는 버그를 바로 해결했습니다.


## 📱 스크린샷
<p align="left">
  <img width="300" alt="스크린샷1" src="https://user-images.githubusercontent.com/81131715/202655821-5f710d15-2f16-40bd-ae13-d4ac612deaba.gif">
</p>


https://user-images.githubusercontent.com/81131715/202655957-1d29bf47-6574-4385-92c8-4900f70e41ff.mov


## ✅ 테스트방법
- Cmd + R

## 📣 PR & Issues
- closed #63 

## 📬 참고문서, 레퍼런스
- https://firebase.google.com/docs/auth/ios/manage-users