### PR TITLE
🐛 ArtistTappedView UI 및 이미지 로드 관련 버그를 수정했습니다.

### DIFF
--- a/Flicker/Network/NetworkManager.swift
+++ b/Flicker/Network/NetworkManager.swift
@@ -48,15 +48,11 @@ class NetworkManager {
 
     func fetchImages(withURLs urls: [String]) async throws -> [UIImage] {
         var images: [UIImage] = []
-        try await withThrowingTaskGroup(of: (UIImage).self) { group in
-            for url in urls {
-                try Task.checkCancellation()
-                group.addTask {
-                    return try await self.fetchOneImage(withURL: url)
-                }
-            }
-            for try await imageDatum in group {
-                images.append(imageDatum)
+
+        for url in urls {
+            let image: UIImage = try await self.fetchOneImage(withURL: url)
+            if !images.contains(image) {
+                images.append(image)
             }
         }
         return images

--- a/Flicker/Screens/Artist/ArtistTappedViewController.swift
+++ b/Flicker/Screens/Artist/ArtistTappedViewController.swift
@@ -20,7 +20,7 @@ final class ArtistTappedViewController: BaseViewController {
         let imageWidth = (UIScreen.main.bounds.width - 50)/3
         $0.itemSize = CGSize(width: imageWidth , height: imageWidth)
         $0.minimumLineSpacing = 5
-        $0.minimumInteritemSpacing = 5
+        $0.minimumInteritemSpacing = 1
         $0.headerReferenceSize = CGSize(width: UIScreen.main.bounds.width, height: CGFloat(headerHeight))
     }
     

--- a/Flicker/Screens/Artist/ArtistTappedViewController.swift
+++ b/Flicker/Screens/Artist/ArtistTappedViewController.swift
@@ -72,7 +72,6 @@ final class ArtistTappedViewController: BaseViewController {
         configUI()
         setupBackButton()
         setupNavigationBar()
-        
     }
     
     override func viewDidDisappear(_ animated: Bool) {
@@ -85,6 +84,7 @@ final class ArtistTappedViewController: BaseViewController {
     override func viewWillDisappear(_ animated: Bool) {
         super.viewWillDisappear(animated)
         navigationController?.navigationBar.backgroundColor = .clear
+        tabBarController?.tabBar.isHidden = false
     }
     
     override func configUI() {
@@ -135,6 +135,19 @@ final class ArtistTappedViewController: BaseViewController {
             }
         } catch {
             print(error)
+        }
+    }
+
+    private func resetNavigationBarBackground() {
+        if collectionView.contentOffset.y > 280 {
+            navigationController?.navigationBar.backgroundColor = .white
+            statusBarBackGroundView.isHidden = false
+            navigationBarSeperator.isHidden = false
+
+        } else {
+            navigationController?.navigationBar.backgroundColor = .clear
+            statusBarBackGroundView.isHidden = true
+            navigationBarSeperator.isHidden = true
         }
     }
     
@@ -245,22 +258,15 @@ extension ArtistTappedViewController: UICollectionViewDelegate {
         viewController.completion = {
             self.statusBarBackGroundView.isHidden = false
             self.navigationBarSeperator.isHidden = false
+            self.tabBarController?.tabBar.isHidden = true
+            self.resetNavigationBarBackground()
         }
         present(viewController, animated: false)
     }
     
     // 스크롤시 네비게이션바 커스텀화
     func scrollViewDidScroll(_ scrollView: UIScrollView) {
-        if collectionView.contentOffset.y > 280 {
-            navigationController?.navigationBar.backgroundColor = .white
-            statusBarBackGroundView.isHidden = false
-            navigationBarSeperator.isHidden = false
-            
-        } else {
-            navigationController?.navigationBar.backgroundColor = .clear
-            statusBarBackGroundView.isHidden = true
-            navigationBarSeperator.isHidden = true
-        }
+        resetNavigationBarBackground()
     }
 }
 

--- a/Flicker/Screens/Artist/ArtistTappedViewController.swift
+++ b/Flicker/Screens/Artist/ArtistTappedViewController.swift
@@ -130,9 +130,11 @@ final class ArtistTappedViewController: BaseViewController {
         do {
             self.imageList = try await networkManager.fetchImages(withURLs: networkManager.portFolioImageList)
             self.collectionView.reloadData()
-            DispatchQueue.main.asyncAfter(deadline: DispatchTime.now() + 0.1) {
+            self.collectionView.performBatchUpdates {
                 self.resetHeaderViewSize()
             }
+            
+            
         } catch {
             print(error)
         }

--- a/Flicker/Screens/Artist/ArtistTappedViewController.swift
+++ b/Flicker/Screens/Artist/ArtistTappedViewController.swift
@@ -133,8 +133,6 @@ final class ArtistTappedViewController: BaseViewController {
             self.collectionView.performBatchUpdates {
                 self.resetHeaderViewSize()
             }
-            
-            
         } catch {
             print(error)
         }
@@ -271,7 +269,6 @@ extension ArtistTappedViewController: UICollectionViewDelegate {
         resetNavigationBarBackground()
     }
 }
-
 
 extension ArtistTappedViewController: UICollectionViewDelegateFlowLayout {
     

--- a/Flicker/Screens/Artist/ImageViewController.swift
+++ b/Flicker/Screens/Artist/ImageViewController.swift
@@ -20,7 +20,7 @@ final class ImageViewController: UIViewController {
 
     private let cancelImageView = UIImageView().then {
         $0.isUserInteractionEnabled = true
-        $0.tintColor = .mainPink
+        $0.tintColor = .white
         $0.contentMode = .scaleAspectFill
         $0.image = UIImage(systemName: "x.circle.fill")
     }
@@ -30,7 +30,7 @@ final class ImageViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         view.addSubviews(imageView, cancelImageView)
-        view.backgroundColor = .white
+        view.backgroundColor = .black
         imageView.image = image
         cancelImageView.addGestureRecognizer(UITapGestureRecognizer(target: self, action: #selector(didTapCancelButton(_:))))
         render()

--- a/Flicker/Screens/Artist/ImageViewController.swift
+++ b/Flicker/Screens/Artist/ImageViewController.swift
@@ -12,7 +12,7 @@ import Then
 final class ImageViewController: UIViewController {
 
     private let imageView = UIImageView().then {
-        $0.contentMode = .scaleAspectFill
+        $0.contentMode = .scaleAspectFit
         $0.clipsToBounds = true
     }
 
@@ -20,7 +20,7 @@ final class ImageViewController: UIViewController {
 
     private let cancelImageView = UIImageView().then {
         $0.isUserInteractionEnabled = true
-        $0.tintColor = .white
+        $0.tintColor = .mainPink
         $0.contentMode = .scaleAspectFill
         $0.image = UIImage(systemName: "x.circle.fill")
     }


### PR DESCRIPTION
## 🌁 배경
UI 작업들을 머지 후 버그 테스트하면서 발견했던 사항들을 수정합니다.

## 👩‍💻 작업 내용 (Content)
### 버그 원인 파악 및 해결

#### 1. 맨 처음 뷰를 그릴 때 헤더뷰가 없어지는 문제 해결
헤더뷰의 사이즈를 reset하는 함수를 reloadData가 확실하게 끝난 후 실행되도록 조정하였습니다.

https://github.com/DeveloperAcademy-POSTECH/MacC-Dime-Flicker/blob/82492d5ac1e6629dce11644905029023474d79fb/Flicker/Screens/Artist/ArtistTappedViewController.swift#L132-L134

#### 정확한 이유는 찾지못했지만 collectionView에서 reloadData과정과 헤더뷰를 등록하는 과정이 동시에 발생하는 것으로 추정됩니다. 
reloadData가 끝나야 그려진 헤더뷰의 subview를 기반으로 헤더뷰 사이즈를 재조정할 수 있는데  reloadData 과정 중에 헤더뷰 사이즈가 넘어오지 않은 상태로 뷰를 그리기 때문에 맨 처음 뷰를 그릴 때 헤더뷰가 그려지지 않은 것으로 생각됩니다.

#### 2. 캐싱 이미지를 가져올 때마다 이미지 리스트의 순서가 바뀌는 문제
이미지 통신 속도를 최적화하기 위해서 여러 장의 이미지를 병렬적으로 (동시에) 통신해서 가져오는 절차를 거치게 됩니다. 
#### 문제는 이 때 이미 다운로드되서 캐싱처리된 이미지를 로드해올 때도 병렬적으로 가져오기 때문에 실제 UIImage 배열의 순서가 그 때 그 때 마다 다르게 됩니다. 
( 캐시에서 이미지를 찾아서 가져오는 과정이 동시에, 비동기적으로 이루어지기 때문에 ABC, BAC, CBA 등으로 순서가 무작위로 들어오게 되는 것으로 추정합니다.)

https://github.com/DeveloperAcademy-POSTECH/MacC-Dime-Flicker/blob/82492d5ac1e6629dce11644905029023474d79fb/Flicker/Network/NetworkManager.swift#L49-L60

결과적으로 원래는 withThrowingTaskGroup 이라는 함수를 써서 하나의 Task 안에 여러 subTask를 그룹으로 묶어서 병렬처리하는 구조였는데 이제는 병렬이 아닌 하나하나 이미지를 다운로드 하는 형태로 바뀌었습니다. 하지만 이미지가 몇장안되서 그런지 눈에 띄는 속도저하는 없었습니다 ㅎㅎ..

#### 3. 아이폰 pro max일 때 collectionView Cell의 배치가 깨지는 문제
collectionView는 셀의 격자형 배치를 위한 레이아웃 옵션으로 flowLayout을 가지고 있습니다. flowLayout에는 셀의 크기에 상관없이 최소한의 간격을 유지하도록 조정하는 minimumInteritemSpacing 이라는 프로퍼티가 있는데요, 이걸 너무 크게 조정해서 발생하는 문제였습니다.
<img width="700" alt="image" src="https://user-images.githubusercontent.com/103009135/202671523-64b0c4b9-4c53-4bb0-88b3-c0ce36f66e91.png">

셀의 크기를 기기 화면 크기에 비례해서 커지게 두었는데, 셀간 가로방향 최소간격은 상수로 두었기 때문에 그 최소의 간격을 유지하기 위해서 셀들이 2열 3행 형태로 바뀌게 된 것입니다.

그래서 이 최소 간격을 조절해서 문제를 해결했습니다.

#### 4. 뒤로가기로 메인뷰로 돌아갔을 때 탭바가 없어지는 문제
작가 디테일뷰는 탭바가 하단에 있을 필요가 없어서 뷰를 그릴 때 configUI 함수에 탭바를 숨기는 코드를 추가했었는데, 뷰가 없어지면 다시 원래대로 돌려놔야했습니다. 그래서 viewLifeCycle을 담당하는 함수 중 적절한 곳에 탭바를 다시 보여지게 하는 코드를 추가했습니다.

추가로 작가 디테일뷰에서 이미지를 클릭하면 이미지가 전체화면으로 잡히고 다시 돌아올 때는 completion 클로저에 탭바를 없애는 코드를 추가했습니다. 그래서 ImageViewController가 없어지고 다시 작가 디테일뷰로 돌아왔을 때도 탭바를 숨길 수 있게 처리했습니다.

#### 그 외 사항
작가 디테일 뷰에서 개별 이미지 클릭시 전체화면이 되었을 때 이미지 비율이 깨진다는 의견이 있었습니다. contentMode를 aspectFit으로 변경해서 해결했습니다.

## 📱 스크린샷
https://user-images.githubusercontent.com/103009135/202673586-feda9859-ebf4-499b-95d0-fefc44baca65.mov

## ✅ 테스트방법
MainViewController 파일의 맨 마지막 함수 (didSelectItem 이 있는 collectionView delegate 함수)에 네비게이션 관련 코드를 추가해서 테스트 해볼 수 있습니다.

=> navigationController?.pushViewController(ArtistTappedViewController(), animated: true)

## 📣 PR & Issues
#67 
