### PR TITLE
프로필뷰에서 네비게이션 바를 지우고 ViewControllerExtension에 네비게이션 관련 함수를 넣었습니다. [#66]

### DIFF
--- a/Flicker/Global/Extensions/UIViewController+Extension.swift
+++ b/Flicker/Global/Extensions/UIViewController+Extension.swift
@@ -8,6 +8,41 @@
 import UIKit
 
 extension UIViewController {
+    
+    enum TransitionStyle {
+        case present
+        case presentNavigation
+        case presentFullNavigation
+        case push
+    }
+    func transition<T: UIViewController>(_ viewController: T, transitionStyle: TransitionStyle = .present) {
+        switch transitionStyle {
+        case .present:
+            self.present(viewController, animated: true)
+            
+        case .presentNavigation:
+            let nav = UINavigationController(rootViewController: viewController)
+            self.present(nav, animated: true)
+            
+        case .presentFullNavigation:
+            let nav = UINavigationController(rootViewController: viewController)
+            nav.modalPresentationStyle = .overFullScreen
+            self.present(nav, animated: true)
+            
+        case .push:
+            self.navigationController?.pushViewController(viewController, animated: true)
+        }
+    }
+    func changeRootView<T: UIViewController>(_ viewController: T) {
+           let windowScene = UIApplication.shared.connectedScenes.first as? UIWindowScene
+           let sceneDelegate = windowScene?.delegate as? SceneDelegate
+           
+           let viewCon = viewController
+           
+           sceneDelegate?.window?.rootViewController = UINavigationController(rootViewController: viewCon)
+           sceneDelegate?.window?.makeKeyAndVisible()
+       }
+
     func makeAlert(title: String,
                    message: String,
                    okAction: ((UIAlertAction) -> Void)? = nil,

--- a/Flicker/Screens/Profile/ProfileViewController.swift
+++ b/Flicker/Screens/Profile/ProfileViewController.swift
@@ -57,12 +57,12 @@ final class ProfileViewController: BaseViewController {
     }
     
     private func setTabGesture() {
-        let tabGesture = UITapGestureRecognizer(target: self, action: #selector(didTapGesture))
+        let tabGesture = UITapGestureRecognizer(target: self, action: #selector(didTapProfileHeader))
         self.profileHeader.addGestureRecognizer(tabGesture)
     }
     
     // MARK: - Setting Functions
-    @objc func didTapGesture() {
+    @objc func didTapProfileHeader() {
         transition(InputPasswordViewController(), transitionStyle: .present)
     }
     

--- a/Flicker/Screens/Profile/ProfileViewController.swift
+++ b/Flicker/Screens/Profile/ProfileViewController.swift
@@ -24,6 +24,7 @@ final class ProfileViewController: BaseViewController {
 
     override func viewDidLoad() {
         super.viewDidLoad()
+//        self.navigationController?.isNavigationBarHidden = true
         setFunctionsAndDelegate()
         render()
         setTabGesture()
@@ -31,7 +32,7 @@ final class ProfileViewController: BaseViewController {
     
     // MARK: - rendering Functions
     override func viewWillAppear(_ animated: Bool) {
-        navigationController?.setNavigationBarHidden(false, animated: true)
+        self.navigationController?.isNavigationBarHidden = true
     }
 
     override func render() {

--- a/Flicker/Screens/Profile/ProfileViewController.swift
+++ b/Flicker/Screens/Profile/ProfileViewController.swift
@@ -24,7 +24,6 @@ final class ProfileViewController: BaseViewController {
 
     override func viewDidLoad() {
         super.viewDidLoad()
-//        self.navigationController?.isNavigationBarHidden = true
         setFunctionsAndDelegate()
         render()
         setTabGesture()
@@ -64,9 +63,7 @@ final class ProfileViewController: BaseViewController {
     
     // MARK: - Setting Functions
     @objc func didTapGesture() {
-        let viewController = InputPasswordViewController()
-        let modalNavigationController = UINavigationController(rootViewController: viewController)
-        present(modalNavigationController, animated: true)
+        transition(InputPasswordViewController(), transitionStyle: .present)
     }
     
     @objc func didToggleSwitch(_ sender: UISwitch) {
@@ -77,8 +74,7 @@ final class ProfileViewController: BaseViewController {
     }
     
     private func goToArtistRegistration() {
-        navigationController?
-            .pushViewController(RegisterWelcomeViewController(), animated: true)
+        transition(RegisterWelcomeViewController(), transitionStyle: .push)
     }
     
     private func goToCustomerInquiry() {
@@ -95,8 +91,7 @@ final class ProfileViewController: BaseViewController {
     }
     
     private func doSignOut() {
-        navigationController?
-            .pushViewController(AccountDeleteViewController(), animated: true)
+        transition(AccountDeleteViewController(), transitionStyle: .push)
     }
 }
 


### PR DESCRIPTION
## 🌁 배경
- Profile에서 UI 관련 버그를 일으키는 요인인 Navigationbar를 지우고 효율성을 향상시키는 조치를 취했습니다.

## 👩‍💻 작업 내용 (Content)

### 문제 
기존 UI에서는 다른 화면으로 이동하여 View가 사라지고 다시 등장하게 되면 전체적인 레이아웃이 굉장히 따로 노는것을 볼 수 있었습니다.

### 해결 
해당 뷰를 떠나고 다시 들어올 때 navigation을 이용하여 들어오게 됩니다. 이 때, 화면에 navigationbar가 등장하여 화면을 가리게 되고 SafeArea와 상호작용으로 전체적인 비율이 어긋나 문제가 일어나는 것으로 보입니다. 이에 화면이 그려질 때마다 네비게이션바를 hidden 처리하여 지우게 되었습니다.

---
### 문제
 네비게이션 관련 코드의 중복선언으로 중복코드가 점점 증가하는 것을 발견하고 현재 상황에서 도움이 되는 방법을 생각해봤습니다.

### 해결
 UIViewController+Extension에 제네릭 타입을 이용하여 두가지 함수를 작성했습니다.
- transition 함수
 - changeRootView 함수

1. transition<T: UIViewController>(_ viewController: T, transitionStyle: TransitionStyle = .present)

transition 함수의 경우에는 총 네가지의 navigation 관련 기능 수행이 가능한 함수로 매개변수로 이동하고자 하는 View와 아래 네가지 방식을 구현하고자 하는 방법에 따라 입력하면 됩니다.
- .present
- .presentNavigation
- .presentFullNavigation
- .push

2. func changeRootView<T: UIViewController>(_ viewController: T)

RootView를 지정한 ViewController가 담당하고 있는 곳으로 바꾸는 기능을 수행하는 함수입니다.



## ✅ 테스트방법
- ProfileViewController를 보시면 사용 예시를 보실수 있습니다.

