### PR TITLE
✨BaseViewController로 이메일 발송 기능 이관 및 신고 양식 개발

### DIFF
--- a/Flicker.xcodeproj/project.pbxproj
+++ b/Flicker.xcodeproj/project.pbxproj
@@ -37,6 +37,7 @@
 		7B3DC43829134DB600646909 /* ProfileHeaderVIew.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B3DC43729134DB600646909 /* ProfileHeaderVIew.swift */; };
 		7B3DC43B2914DA3000646909 /* ProfileTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B3DC43A2914DA3000646909 /* ProfileTableViewCell.swift */; };
 		7B3DC43D2914DA8C00646909 /* ProfileEnumeration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B3DC43C2914DA8C00646909 /* ProfileEnumeration.swift */; };
+		7B589122292B6568008A950E /* EmailViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B589121292B6568008A950E /* EmailViewController.swift */; };
 		A94957F6290E3A4900B74693 /* NetworkErrorCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = A94957F5290E3A4900B74693 /* NetworkErrorCase.swift */; };
 		A94957F8290E3A6000B74693 /* APIResponseDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = A94957F7290E3A6000B74693 /* APIResponseDTO.swift */; };
 		A94957FA290E3A8300B74693 /* NetworkManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = A94957F9290E3A8300B74693 /* NetworkManager.swift */; };
@@ -120,6 +121,7 @@
 		7B3DC43729134DB600646909 /* ProfileHeaderVIew.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfileHeaderVIew.swift; sourceTree = "<group>"; };
 		7B3DC43A2914DA3000646909 /* ProfileTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfileTableViewCell.swift; sourceTree = "<group>"; };
 		7B3DC43C2914DA8C00646909 /* ProfileEnumeration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfileEnumeration.swift; sourceTree = "<group>"; };
+		7B589121292B6568008A950E /* EmailViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EmailViewController.swift; sourceTree = "<group>"; };
 		A94957F5290E3A4900B74693 /* NetworkErrorCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkErrorCase.swift; sourceTree = "<group>"; };
 		A94957F7290E3A6000B74693 /* APIResponseDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APIResponseDTO.swift; sourceTree = "<group>"; };
 		A94957F9290E3A8300B74693 /* NetworkManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkManager.swift; sourceTree = "<group>"; };
@@ -453,6 +455,7 @@
 				CBDC03FA29060F6E00C6CF30 /* FirebaseManager.swift */,
 				CBDC03FC29060F7A00C6CF30 /* PushNotificationSender.swift */,
 				102A4BEA29253AB2005A8BE5 /* LoginManager.swift */,
+				7B589121292B6568008A950E /* EmailViewController.swift */,
 			);
 			path = Utils;
 			sourceTree = "<group>";
@@ -716,6 +719,7 @@
 				CB5BF47A2919E10700A3E112 /* ChannelTableViewCell.swift in Sources */,
 				CBDC04092906102F00C6CF30 /* UIView+Extension.swift in Sources */,
 				CB5BF4832919E1A800A3E112 /* PaddingLabel.swift in Sources */,
+				7B589122292B6568008A950E /* EmailViewController.swift in Sources */,
 				7B3DC43B2914DA3000646909 /* ProfileTableViewCell.swift in Sources */,
 				A94957FC290E3DF500B74693 /* AccessKey.swift in Sources */,
 				CB5BF47F2919E15400A3E112 /* RecentMessage.swift in Sources */,

--- a/Flicker/Global/Base/BaseViewController.swift
+++ b/Flicker/Global/Base/BaseViewController.swift
@@ -12,6 +12,7 @@ import AuthenticationServices
 import Firebase
 import FirebaseAuth
 import FirebaseFirestore
+import MessageUI
 
 class BaseViewController: UIViewController {
     // MARK: - property
@@ -187,5 +188,94 @@ extension BaseViewController {
         if textField.text == checkTextField.text {
             return true
         } else { return false }
+    }
+}
+
+// MARK: - MFMailComposeViewControllerDelegate. 해당 델리게이트를 이용하여 email 송신 기능 가능
+extension BaseViewController: MFMailComposeViewControllerDelegate {
+    enum ReportType {
+        case askSomething
+        case reportAnotherUser
+        case reportChatUser
+    }
+    
+    func sendReportMail(userName: String?, reportType: ReportType) {
+        if MFMailComposeViewController.canSendMail() {
+            let formatter = DateFormatter()
+            formatter.dateFormat = "yyyy-MM-dd HH:mm"
+            let currentDateString = formatter.string(from: Date())
+            let composeViewController = MFMailComposeViewController()
+            let dimeEmail = "haptic_04_minis@icloud.com"
+            switch reportType {
+            case .askSomething:
+                let messageBody = """
+                                  -----------------------------
+                                  - 문의하시는 분: \(String(describing: userName ?? "UNKNOWN"))
+                                  - 문의 날짜: \(currentDateString)
+                                  ------------------------------
+                                  - 내용
+                                  
+                                  
+                                  
+                                  
+                                  """
+                composeViewController.mailComposeDelegate = self
+                composeViewController.setToRecipients([dimeEmail])
+                composeViewController.setSubject("")
+                composeViewController.setMessageBody(messageBody, isHTML: false)
+                self.present(composeViewController, animated: true, completion: nil)
+            case .reportAnotherUser:
+                let messageBody = """
+                                  -----------------------------
+                                  - 신고자: \(String(describing: userName ?? "UNKNOWN"))
+                                  - 일시: \(currentDateString)
+                                  ------------------------------
+                                  - 신고 사유 (상대의 이름, 왜 신고하시는지)
+                                  
+                                  
+                                  
+                                  
+                                  """
+                composeViewController.mailComposeDelegate = self
+                composeViewController.setToRecipients([dimeEmail])
+                composeViewController.setSubject("")
+                composeViewController.setMessageBody(messageBody, isHTML: false)
+                self.present(composeViewController, animated: true, completion: nil)
+            case .reportChatUser:
+                let messageBody = """
+                                  -----------------------------
+                                  - 신고자: \(String(describing: userName ?? "UNKNOWN"))
+                                  - 신고일시: \(currentDateString)
+                                  ------------------------------
+                                  - 신고사유
+                                  
+                                  
+                                  
+                                  
+                                  """
+                composeViewController.mailComposeDelegate = self
+                composeViewController.setToRecipients([dimeEmail])
+                composeViewController.setSubject("")
+                composeViewController.setMessageBody(messageBody, isHTML: false)
+                self.present(composeViewController, animated: true, completion: nil)
+            }
+        }
+        else {
+            showSendMailErrorAlert()
+        }
+    }
+
+    func showSendMailErrorAlert() {
+        let sendMailErrorAlert = UIAlertController(title: "메일 전송 실패", message: "아이폰 이메일 설정을 확인하고 다시 시도해주세요.", preferredStyle: .alert)
+        let confirmAction = UIAlertAction(title: "확인", style: .default) {
+            (action) in
+            print("확인")
+        }
+        sendMailErrorAlert.addAction(confirmAction)
+        self.present(sendMailErrorAlert, animated: true, completion: nil)
+    }
+
+    func mailComposeController(_ controller: MFMailComposeViewController, didFinishWith result: MFMailComposeResult, error: Error?) {
+        controller.dismiss(animated: true, completion: nil)
     }
 }

--- a/Flicker/Global/Base/BaseViewController.swift
+++ b/Flicker/Global/Base/BaseViewController.swift
@@ -12,7 +12,6 @@ import AuthenticationServices
 import Firebase
 import FirebaseAuth
 import FirebaseFirestore
-import MessageUI
 
 class BaseViewController: UIViewController {
     // MARK: - property
@@ -188,94 +187,5 @@ extension BaseViewController {
         if textField.text == checkTextField.text {
             return true
         } else { return false }
-    }
-}
-
-// MARK: - MFMailComposeViewControllerDelegate. 해당 델리게이트를 이용하여 email 송신 기능 가능
-extension BaseViewController: MFMailComposeViewControllerDelegate {
-    enum ReportType {
-        case askSomething
-        case reportAnotherUser
-        case reportChatUser
-    }
-    
-    func sendReportMail(userName: String?, reportType: ReportType) {
-        if MFMailComposeViewController.canSendMail() {
-            let formatter = DateFormatter()
-            formatter.dateFormat = "yyyy-MM-dd HH:mm"
-            let currentDateString = formatter.string(from: Date())
-            let composeViewController = MFMailComposeViewController()
-            let dimeEmail = "haptic_04_minis@icloud.com"
-            switch reportType {
-            case .askSomething:
-                let messageBody = """
-                                  -----------------------------
-                                  - 문의하시는 분: \(String(describing: userName ?? "UNKNOWN"))
-                                  - 문의 날짜: \(currentDateString)
-                                  ------------------------------
-                                  - 내용
-                                  
-                                  
-                                  
-                                  
-                                  """
-                composeViewController.mailComposeDelegate = self
-                composeViewController.setToRecipients([dimeEmail])
-                composeViewController.setSubject("")
-                composeViewController.setMessageBody(messageBody, isHTML: false)
-                self.present(composeViewController, animated: true, completion: nil)
-            case .reportAnotherUser:
-                let messageBody = """
-                                  -----------------------------
-                                  - 신고자: \(String(describing: userName ?? "UNKNOWN"))
-                                  - 일시: \(currentDateString)
-                                  ------------------------------
-                                  - 신고 사유 (상대의 이름, 왜 신고하시는지)
-                                  
-                                  
-                                  
-                                  
-                                  """
-                composeViewController.mailComposeDelegate = self
-                composeViewController.setToRecipients([dimeEmail])
-                composeViewController.setSubject("")
-                composeViewController.setMessageBody(messageBody, isHTML: false)
-                self.present(composeViewController, animated: true, completion: nil)
-            case .reportChatUser:
-                let messageBody = """
-                                  -----------------------------
-                                  - 신고자: \(String(describing: userName ?? "UNKNOWN"))
-                                  - 신고일시: \(currentDateString)
-                                  ------------------------------
-                                  - 신고사유
-                                  
-                                  
-                                  
-                                  
-                                  """
-                composeViewController.mailComposeDelegate = self
-                composeViewController.setToRecipients([dimeEmail])
-                composeViewController.setSubject("")
-                composeViewController.setMessageBody(messageBody, isHTML: false)
-                self.present(composeViewController, animated: true, completion: nil)
-            }
-        }
-        else {
-            showSendMailErrorAlert()
-        }
-    }
-
-    func showSendMailErrorAlert() {
-        let sendMailErrorAlert = UIAlertController(title: "메일 전송 실패", message: "아이폰 이메일 설정을 확인하고 다시 시도해주세요.", preferredStyle: .alert)
-        let confirmAction = UIAlertAction(title: "확인", style: .default) {
-            (action) in
-            print("확인")
-        }
-        sendMailErrorAlert.addAction(confirmAction)
-        self.present(sendMailErrorAlert, animated: true, completion: nil)
-    }
-
-    func mailComposeController(_ controller: MFMailComposeViewController, didFinishWith result: MFMailComposeResult, error: Error?) {
-        controller.dismiss(animated: true, completion: nil)
     }
 }

--- a/Flicker/Global/Utils/EmailViewController.swift
+++ b/Flicker/Global/Utils/EmailViewController.swift
@@ -1,0 +1,105 @@
+//
+//  EmailViewController.swift
+//  Flicker
+//
+//  Created by Taehwan Kim on 2022/11/21.
+//
+
+import UIKit
+import MessageUI
+
+enum ReportType {
+    case askSomething
+    case reportAnotherUser
+    case reportChatUser
+}
+
+class EmailViewController: BaseViewController {
+    override func viewDidLoad() {
+        super.viewDidLoad()
+    }
+}
+
+// MARK: - MFMailComposeViewControllerDelegate. 해당 델리게이트를 이용하여 email 송신 기능 가능
+extension EmailViewController: MFMailComposeViewControllerDelegate {
+    
+    func sendReportMail(userName: String?, reportType: ReportType) {
+        if MFMailComposeViewController.canSendMail() {
+            let formatter = DateFormatter()
+            formatter.dateFormat = "yyyy-MM-dd HH:mm"
+            let currentDateString = formatter.string(from: Date())
+            let composeViewController = MFMailComposeViewController()
+            let dimeEmail = "haptic_04_minis@icloud.com"
+            switch reportType {
+            case .askSomething:
+                let messageBody = """
+                                  -----------------------------
+                                  - 문의하시는 분: \(String(describing: userName ?? "UNKNOWN"))
+                                  - 문의 날짜: \(currentDateString)
+                                  ------------------------------
+                                  - 내용
+                                  
+                                  
+                                  
+                                  
+                                  """
+                composeViewController.mailComposeDelegate = self
+                composeViewController.setToRecipients([dimeEmail])
+                composeViewController.setSubject("")
+                composeViewController.setMessageBody(messageBody, isHTML: false)
+                self.present(composeViewController, animated: true, completion: nil)
+            case .reportAnotherUser:
+                let messageBody = """
+                                  -----------------------------
+                                  - 신고자: \(String(describing: userName ?? "UNKNOWN"))
+                                  - 일시: \(currentDateString)
+                                  ------------------------------
+                                  - 신고 사유 (상대의 이름, 왜 신고하시는지)
+                                  
+                                  
+                                  
+                                  
+                                  """
+                composeViewController.mailComposeDelegate = self
+                composeViewController.setToRecipients([dimeEmail])
+                composeViewController.setSubject("")
+                composeViewController.setMessageBody(messageBody, isHTML: false)
+                self.present(composeViewController, animated: true, completion: nil)
+            case .reportChatUser:
+                let messageBody = """
+                                  -----------------------------
+                                  - 신고자: \(String(describing: userName ?? "UNKNOWN"))
+                                  - 신고일시: \(currentDateString)
+                                  ------------------------------
+                                  - 신고사유
+                                  
+                                  
+                                  
+                                  
+                                  """
+                composeViewController.mailComposeDelegate = self
+                composeViewController.setToRecipients([dimeEmail])
+                composeViewController.setSubject("")
+                composeViewController.setMessageBody(messageBody, isHTML: false)
+                self.present(composeViewController, animated: true, completion: nil)
+            }
+        }
+        else {
+            showSendMailErrorAlert()
+        }
+    }
+
+    func showSendMailErrorAlert() {
+        let sendMailErrorAlert = UIAlertController(title: "메일 전송 실패", message: "아이폰 이메일 설정을 확인하고 다시 시도해주세요.", preferredStyle: .alert)
+        let confirmAction = UIAlertAction(title: "확인", style: .default) {
+            (action) in
+            print("확인")
+        }
+        sendMailErrorAlert.addAction(confirmAction)
+        self.present(sendMailErrorAlert, animated: true, completion: nil)
+    }
+
+    func mailComposeController(_ controller: MFMailComposeViewController, didFinishWith result: MFMailComposeResult, error: Error?) {
+        controller.dismiss(animated: true, completion: nil)
+    }
+}

--- a/Flicker/Screens/Profile/ProfileViewController.swift
+++ b/Flicker/Screens/Profile/ProfileViewController.swift
@@ -5,7 +5,6 @@
 //  Created by Taehwan Kim on 2022/11/02.
 //
 
-import MessageUI
 import UIKit
 import AuthenticationServices
 import FirebaseAuth
@@ -13,7 +12,7 @@ import FirebaseAuth
 final class ProfileViewController: BaseViewController {
     
     // MARK: - Properties
-    private let userName: String? = nil
+    private let userName: String? = "testString" ?? "Error"
     private var isArtist: Bool = false
     private let sectionHeaderTitle = ["설정"]
     private let userProfileCell = UIView(frame: .zero)
@@ -87,7 +86,7 @@ final class ProfileViewController: BaseViewController {
     }
 
     private func goToCustomerInquiry() {
-        self.sendReportMail()
+        sendReportMail(userName: userName, reportType: .askSomething)
     }
 
     private func doLogout() {
@@ -176,51 +175,5 @@ extension ProfileViewController: UITableViewDelegate {
                 break
             }
         }
-    }
-}
-
-// MARK: - MFMailComposeViewControllerDelegate. 해당 델리게이트를 이용하여 email 송신 기능 가능
-extension ProfileViewController: MFMailComposeViewControllerDelegate {
-    func sendReportMail() {
-        if MFMailComposeViewController.canSendMail() {
-            let formatter = DateFormatter()
-            formatter.dateFormat = "yyyy-MM-dd HH:mm"
-            let currentDateString = formatter.string(from: Date())
-            let composeViewController = MFMailComposeViewController()
-            let dimeEmail = "haptic_04_minis@icloud.com"
-            let messageBody = """
-                              -----------------------------
-                              - 문의하시는 분: \(String(describing: userName ?? "UNKNOWN"))
-                              - 문의 날짜: \(currentDateString)
-                              ------------------------------
-                              - 내용
-                              
-                              
-                              
-                              
-                              """
-            composeViewController.mailComposeDelegate = self
-            composeViewController.setToRecipients([dimeEmail])
-            composeViewController.setSubject("")
-            composeViewController.setMessageBody(messageBody, isHTML: false)
-            self.present(composeViewController, animated: true, completion: nil)
-        }
-        else {
-            self.showSendMailErrorAlert()
-        }
-    }
-
-    private func showSendMailErrorAlert() {
-        let sendMailErrorAlert = UIAlertController(title: "메일 전송 실패", message: "아이폰 이메일 설정을 확인하고 다시 시도해주세요.", preferredStyle: .alert)
-        let confirmAction = UIAlertAction(title: "확인", style: .default) {
-            (action) in
-            print("확인")
-        }
-        sendMailErrorAlert.addAction(confirmAction)
-        self.present(sendMailErrorAlert, animated: true, completion: nil)
-    }
-
-    func mailComposeController(_ controller: MFMailComposeViewController, didFinishWith result: MFMailComposeResult, error: Error?) {
-        controller.dismiss(animated: true, completion: nil)
     }
 }

--- a/Flicker/Screens/Profile/ProfileViewController.swift
+++ b/Flicker/Screens/Profile/ProfileViewController.swift
@@ -9,7 +9,7 @@ import UIKit
 import AuthenticationServices
 import FirebaseAuth
 
-final class ProfileViewController: BaseViewController {
+final class ProfileViewController: EmailViewController {
     
     // MARK: - Properties
     private let userName: String? = "testString" ?? "Error"


### PR DESCRIPTION
## 🌁 배경
- 신고하기 기능이 다양한 곳에서 쓰임에 따라 개발의 필요가 있었습니다.

## 👩‍💻 작업 내용 (Content)
- 현재 이메일 발송 기능의 경우 ProfileViewController에만 존재했습니다.
- 이를 BaseViewController로 이동시켜 상속 받는 모든 ViewController에서 해당 기능을 이용할 수 있도록 했습니다.

## 사용법

sendReportMail(userName: "현재 로그인된 유저의 닉네임", reportType: .askSomething)
위와 같은 형식으로 함수를 이용합니다.

현재 리포트하는 양식으로 세가지가 있습니다.
- .askSomething
사용자가 서비스에 대해 문의할 수 있는 양식이 있습니다.
- .reportAnotherUser
사용자가 게시글 기반으로 사용자를 신고할 수 있는 양식이 있습니다.
- .reportChatUser
사용자가 채팅 진행중인 상대방을 신고할 수 있는 양식이 있습니다.


## ✅ 테스트방법
- BaseViewController를 상속하는 ViewController에서 위에 언급한 함수를 호출해서 확인하시면 됩니다.

