### PR TITLE
✨ UserDefault에 있는 값을 회원가입 및 로그아웃 할때 삭제하는 코드를 추가했습니다.

### DIFF
--- a/Flicker/Models/User.swift
+++ b/Flicker/Models/User.swift
@@ -27,4 +27,12 @@ final class CurrentUserDataManager {
             defaults.set(userData.token, forKey: "currentUserToken")
         }
     }
+
+    func deleteUserDefault() async {
+        defaults.removeObject(forKey: "currentUserEmail")
+        defaults.removeObject(forKey: "currentUserName")
+        defaults.removeObject(forKey: "currentUserProfileImageUrl")
+        defaults.removeObject(forKey: "currentUserToken")
+        defaults.removeObject(forKey: "regions")
+    }
 }

--- a/Flicker/Screens/Profile/ProfileViewController.swift
+++ b/Flicker/Screens/Profile/ProfileViewController.swift
@@ -96,6 +96,7 @@ final class ProfileViewController: BaseViewController {
         makeRequestAlert(title: "로그아웃 하시겠어요?", message: "", okAction: { _ in
             Task {
                 [weak self] in
+                await CurrentUserDataManager.shared.deleteUserDefault()
                 await LoginManager.shared.fireBaseSignOut()
                 DispatchQueue.main.async {
                     self?.goLogin()
@@ -107,6 +108,7 @@ final class ProfileViewController: BaseViewController {
     private func doSignOut() {
         makeRequestAlert(title: "정말 탈퇴하시겠어요?", message: "회원님의 가입정보는 즉시 삭제되며, 복구가 불가능합니다.", okAction: { _ in
             Task { [weak self] in
+                await CurrentUserDataManager.shared.deleteUserDefault()
                 await LoginManager.shared.appleLoginReAuthUser()
                 await LoginManager.shared.fireBasewithDraw()
                 self?.navigationController?


### PR DESCRIPTION
## 🌁 배경
- UserDefault에 값을 저장만 하고 로그아웃하거나 회원탈퇴 할때 삭제하는 기능이 없어 로그아웃 후 앱을 들어가도 메인 뷰에서 지역이 전에 설정했던 데로 그대로 남아있어 이를 삭제하는 코드를 추가했습니다.

## 👩‍💻 작업 내용 (Content)
- UserDefault 저장된 값을 삭제하는 코드를 추가했습니다.

## ✅ 테스트방법
- 로그아웃 혹은 회원탈퇴 후 메인화면에서 지역태그 값이 초기화가 되어있음을 확인하면 됩니다.

## 📣 PR & Issues
- closed #104