### PR TITLE
✨ 🐛 서버에 중복된 이메일이여도 로그인처리되는 것 처럼 보이는 버그를 해결했습니다.

### DIFF
--- a/Flicker/Global/Utils/FirebaseManager.swift
+++ b/Flicker/Global/Utils/FirebaseManager.swift
@@ -134,6 +134,24 @@ final class FirebaseManager: NSObject {
             return nil
         }
     }
+/*파이어 베이스에서 Email필드에 값을 불러오는데 서치 값이 없을 경우 빈 배열을 불러온다. 빈 배열일 경우 사용자가 적은 이메일 값이
+ 없고, 배열에 값이 존재할 경우 사용자가 사용하려는 이메일은 이미 존재함을 의미한다. */
+    func isEmailSameExist(Email: String) async -> Bool? {
+        do {
+            let document = try await firestore.collection("users").whereField("email", isEqualTo: Email).getDocuments()
+            if document.isEmpty {
+                print("Email don't Exist")
+                return false
+            } else {
+                print("Already exist Email")
+                return true
+            }
+        } catch {
+            print(error)
+            return nil
+        }
+    }
+
     
     func createChatMessage(currentUser: User, chatUser: User, chatText: String) {
         

--- a/Flicker/Screens/SignUp/SignUpViewController.swift
+++ b/Flicker/Screens/SignUp/SignUpViewController.swift
@@ -182,20 +182,22 @@ final class SignUpViewController: BaseViewController {
     }
     //
     @objc private func didTapSignUpButton() {
-
-        let viewController = LoginProfileViewController()
-        guard let email = emailField.text, emailValidCheck(emailField),
-              let password = passwordField.text, passwordValidCheck(passwordField),
-              let passwordCheck = passwordSameCheckField.text, passwordSameCheck(passwordField, passwordSameCheckField) else {
-            print("Missing field data")
-            return
+        Task { [weak self] in
+            await FirebaseManager.shared.isEmailSameExist(Email: emailField.text ?? "")
         }
-
-        viewController.authEmail = email
-        viewController.authPassword = passwordCheck
-        viewController.isSignUpEmail = self.didTapSignUpEmail
-
-        self.navigationController?.pushViewController(viewController, animated: true)
+//        let viewController = LoginProfileViewController()
+//        guard let email = emailField.text, emailValidCheck(emailField),
+//              let password = passwordField.text, passwordValidCheck(passwordField),
+//              let passwordCheck = passwordSameCheckField.text, passwordSameCheck(passwordField, passwordSameCheckField) else {
+//            print("Missing field data")
+//            return
+//        }
+//
+//        viewController.authEmail = email
+//        viewController.authPassword = passwordCheck
+//        viewController.isSignUpEmail = self.didTapSignUpEmail
+//
+//        self.navigationController?.pushViewController(viewController, animated: true)
 
     }
 }

--- a/Flicker/Screens/SignUp/SignUpViewController.swift
+++ b/Flicker/Screens/SignUp/SignUpViewController.swift
@@ -180,25 +180,28 @@ final class SignUpViewController: BaseViewController {
 
         title = "프로필 입력"
     }
-    //
-    @objc private func didTapSignUpButton() {
-        Task { [weak self] in
-            await FirebaseManager.shared.isEmailSameExist(Email: emailField.text ?? "")
-        }
-//        let viewController = LoginProfileViewController()
-//        guard let email = emailField.text, emailValidCheck(emailField),
-//              let password = passwordField.text, passwordValidCheck(passwordField),
-//              let passwordCheck = passwordSameCheckField.text, passwordSameCheck(passwordField, passwordSameCheckField) else {
-//            print("Missing field data")
-//            return
-//        }
-//
-//        viewController.authEmail = email
-//        viewController.authPassword = passwordCheck
-//        viewController.isSignUpEmail = self.didTapSignUpEmail
-//
-//        self.navigationController?.pushViewController(viewController, animated: true)
 
+    @objc private func didTapSignUpButton() {
+        let viewController = LoginProfileViewController()
+        guard let email = emailField.text, emailValidCheck(emailField),
+              let password = passwordField.text, passwordValidCheck(passwordField),
+              let passwordCheck = passwordSameCheckField.text, passwordSameCheck(passwordField, passwordSameCheckField) else {
+            print("Missing field data")
+            return
+        }
+
+        viewController.authEmail = email
+        viewController.authPassword = passwordCheck
+        viewController.isSignUpEmail = self.didTapSignUpEmail
+        
+        Task { [weak self] in
+            guard let isExistEmail = await FirebaseManager.shared.isEmailSameExist(Email: emailField.text ?? "") else { return }
+            if isExistEmail {
+                makeAlert(title: "이미 사용중인 메일 주소입니다.", message: "")
+            } else {
+                self?.navigationController?.pushViewController(viewController, animated: true)
+            }
+        }
     }
 }
 


### PR DESCRIPTION
## 🌁 배경
- 이메일이 서버에 있으면 회원가입할때 유저데이터가 생성되지 않지만 화면은 넘어가는 버그가 존재했습니다.

- 이를 해결하기 위해 서버에서 이메일 존재여부를 체크하여 이메일이 중복되면 넘어갈 수 없도록 UX를 수정해야했습니다.

## 👩‍💻 작업 내용 (Content)
- 유저가 입력한 이메일 값을 서버와의 통신을 통해 값을 리턴받는 식으로 함수를 만들었습니다.

- 리턴받을때 이미 있는 이메일이면 쿼리의 주소값을 배열로 받으며 존재하지 않는 이메일은 빈 배열을 리턴받습니다.

- 이를 이용하여 받는 값에 대해 isEmpty를 활용하여 함수의 리턴값을 boolean형식으로 하여 분기처리를 했습니다.

## 📱 스크린샷
- 화면 전환이나 인터렉션이 있는 경우엔 GIF, 정적인 화면이라면 스크린샷을 이용합니다.

<p align="left">
  <img width="300" alt="스크린샷1" src="https://user-images.githubusercontent.com/81131715/203237271-62ff95e6-5352-45fe-a110-8d3bd5f6268e.gif">
</p>

## ✅ 테스트방법
- 파이어베이스 서버내의 이미 있는 이메일로 로그인 하는 경우 화면이 넘어갈 수 없도록 구현했습니다.

## 📣 PR & Issues
- closed #106 

## 📬 참고문서, 레퍼런스
- https://firebase.google.com/docs/firestore/query-data/queries#swift
- PR #110 
