### PR TITLE
✨🐛💄 프로필세팅뷰의 기능을 붙였습니다.

### DIFF
--- a/Flicker/Models/User.swift
+++ b/Flicker/Models/User.swift
@@ -16,7 +16,6 @@ struct User: Codable, Identifiable {
 final class CurrentUserDataManager {
 
     static let shared = CurrentUserDataManager()
-
     private let defaults = UserDefaults.standard
 
     func saveUserDefault() async {

--- a/Flicker/Screens/Profile/ProfileViewController.swift
+++ b/Flicker/Screens/Profile/ProfileViewController.swift
@@ -75,7 +75,7 @@ final class ProfileViewController: EmailViewController {
         let vc = ProfileSettingViewController()
         Task {
             let imageURL = defaults.string(forKey: "currentUserProfileImageUrl") ?? "https://cdn.pixabay.com/photo/2012/04/12/20/12/x-30465_1280.png"
-            vc.existingName = defaults.string(forKey: "currentUserName") ?? "Error"
+            vc.currentUserName = defaults.string(forKey: "currentUserName") ?? "Error"
             vc.profileImageView.image = try await NetworkManager.shared.fetchOneImage(withURL: imageURL)
         }
         transition(vc, transitionStyle: .push)

--- a/Flicker/Screens/Profile/ProfileViewController.swift
+++ b/Flicker/Screens/Profile/ProfileViewController.swift
@@ -31,11 +31,6 @@ final class ProfileViewController: EmailViewController {
         setFunctionsAndDelegate()
         render()
         setTabGesture()
-        print("================================")
-        print(defaults.string(forKey: "currentUserEmail"))
-        print(defaults.string(forKey: "currentUserName"))
-        print(defaults.string(forKey: "currentUserProfileImageUrl"))
-        print("================================")
     }
     
     override func viewWillAppear(_ animated: Bool) {
@@ -78,9 +73,9 @@ final class ProfileViewController: EmailViewController {
     
     @objc func didTapProfileHeader() {
         let vc = ProfileSettingViewController()
-        vc.existingName = "aaa"
         Task {
-            let imageURL = defaults.string(forKey: "currentUserProfileImageUrl") ?? ""
+            let imageURL = defaults.string(forKey: "currentUserProfileImageUrl") ?? "https://cdn.pixabay.com/photo/2012/04/12/20/12/x-30465_1280.png"
+            vc.existingName = defaults.string(forKey: "currentUserName") ?? "Error"
             vc.profileImageView.image = try await NetworkManager.shared.fetchOneImage(withURL: imageURL)
         }
         transition(vc, transitionStyle: .push)
@@ -134,13 +129,6 @@ extension ProfileViewController: UITableViewDataSource {
         if indexPath.item == 0 {
             Task {
                 await profileHeader.setupHeaderData(name: defaults.string(forKey: "currentUserName") ?? "", email: defaults.string(forKey: "currentUserEmail") ?? "", imageURL: defaults.string(forKey: "currentUserProfileImageUrl") ?? "")
-            }
-        }
-        if indexPath.item == 1 {
-            Task {
-                await profileSettingView.setProfileImage(name: defaults.string(forKey: "currentUserName") ?? "", imageUrl: defaults.string(forKey: "currentUserProfileImageUrl") ?? "")
-                print(defaults.string(forKey: "currentUserName"))
-                print(defaults.string(forKey: "currentUserProfileImageUrl"))
             }
         }
         // section에 !가 붙었는데 코드가 바뀌지 않는 이상 강제 언래핑을 해도 무관하다고 생각합니다.

--- a/Flicker/Screens/Profile/ProfileViewController.swift
+++ b/Flicker/Screens/Profile/ProfileViewController.swift
@@ -31,6 +31,11 @@ final class ProfileViewController: EmailViewController {
         setFunctionsAndDelegate()
         render()
         setTabGesture()
+        print("================================")
+        print(defaults.string(forKey: "currentUserEmail"))
+        print(defaults.string(forKey: "currentUserName"))
+        print(defaults.string(forKey: "currentUserProfileImageUrl"))
+        print("================================")
     }
     
     override func viewWillAppear(_ animated: Bool) {

--- a/Flicker/Screens/Profile/ProfileViewController.swift
+++ b/Flicker/Screens/Profile/ProfileViewController.swift
@@ -74,8 +74,9 @@ final class ProfileViewController: EmailViewController {
     @objc func didTapProfileHeader() {
         let vc = ProfileSettingViewController()
         Task {
-            let imageURL = defaults.string(forKey: "currentUserProfileImageUrl") ?? "https://cdn.pixabay.com/photo/2012/04/12/20/12/x-30465_1280.png"
-            vc.currentUserName = defaults.string(forKey: "currentUserName") ?? "Error"
+            guard let imageURL = defaults.string(forKey: "currentUserProfileImageUrl") else { return }
+            guard let currentUserName = defaults.string(forKey: "currentUserName") else { return }
+            vc.currentUserName = currentUserName
             vc.profileImageView.image = try await NetworkManager.shared.fetchOneImage(withURL: imageURL)
         }
         transition(vc, transitionStyle: .push)

--- a/Flicker/Screens/Profile/ProfileViewController.swift
+++ b/Flicker/Screens/Profile/ProfileViewController.swift
@@ -14,7 +14,7 @@ final class ProfileViewController: EmailViewController {
     private let userName: String? = nil
     private var isArtist: Bool = false
     private let defaults = UserDefaults.standard
-    
+    private let profileSettingView = ProfileSettingViewController()
     // MARK: - Properties: UITable layout
     private let sectionHeaderTitle = ["설정"]
     private let userProfileCell = UIView(frame: .zero)
@@ -77,7 +77,13 @@ final class ProfileViewController: EmailViewController {
     }
     
     @objc func didTapProfileHeader() {
-        transition(ProfileSettingViewController(), transitionStyle: .push)
+        let vc = ProfileSettingViewController()
+        vc.existingName = "aaa"
+        Task {
+            let imageURL = defaults.string(forKey: "currentUserProfileImageUrl") ?? ""
+            vc.profileImageView.image = try await NetworkManager.shared.fetchOneImage(withURL: imageURL)
+        }
+        transition(vc, transitionStyle: .push)
     }
 
 
@@ -128,6 +134,13 @@ extension ProfileViewController: UITableViewDataSource {
         if indexPath.item == 0 {
             Task {
                 await profileHeader.setupHeaderData(name: defaults.string(forKey: "currentUserName") ?? "", email: defaults.string(forKey: "currentUserEmail") ?? "", imageURL: defaults.string(forKey: "currentUserProfileImageUrl") ?? "")
+            }
+        }
+        if indexPath.item == 1 {
+            Task {
+                await profileSettingView.setProfileImage(name: defaults.string(forKey: "currentUserName") ?? "", imageUrl: defaults.string(forKey: "currentUserProfileImageUrl") ?? "")
+                print(defaults.string(forKey: "currentUserName"))
+                print(defaults.string(forKey: "currentUserProfileImageUrl"))
             }
         }
         // section에 !가 붙었는데 코드가 바뀌지 않는 이상 강제 언래핑을 해도 무관하다고 생각합니다.

--- a/Flicker/Screens/ProfileSetting/ProfileSettingViewController.swift
+++ b/Flicker/Screens/ProfileSetting/ProfileSettingViewController.swift
@@ -9,6 +9,7 @@ import UIKit
 import SnapKit
 import Then
 import FirebaseAuth
+import Firebase
 /*
  LoginProfileViewController와 같은 뷰이지만 재사용성을 강조해 두 뷰를 종속시키는 것 보다
  그냥 같은 뷰를 새로 그려 따로 관리하는 것이 더 효율적이라고 생각이 되어 거의 같은 코드를 쓰는 뷰가 두 개가 있습니다.
@@ -16,14 +17,16 @@ import FirebaseAuth
 final class ProfileSettingViewController: BaseViewController {
     private var isNickNameWrite = false
     private let defaults = UserDefaults.standard
-    private var ExistingName: String = ""
+    var existingName: String = ""
+    private var existingImageUrl: String = ""
     private lazy var imagePicker = UIImagePickerController().then {
         $0.sourceType = .photoLibrary
         $0.allowsEditing = true
         $0.delegate = self
     }
 
-    private lazy var profileImageView = UIImageView().then {
+    lazy var profileImageView = UIImageView().then {
+        $0.image = UIImage(named: "DefaultProfile")
         $0.backgroundColor = .loginGray
         $0.layer.cornerRadius = 50
         $0.clipsToBounds = true
@@ -31,7 +34,7 @@ final class ProfileSettingViewController: BaseViewController {
         $0.addGestureRecognizer(UITapGestureRecognizer(target: self, action: #selector(selectButtonTouched)))
     }
 
-    private let cameraImage = UIImageView().then {
+    private lazy var cameraImage = UIImageView().then {
         $0.tintColor = .black
         $0.image = UIImage(systemName: "camera")
     }
@@ -58,7 +61,7 @@ final class ProfileSettingViewController: BaseViewController {
         ]
 
         $0.backgroundColor = .clear
-        $0.attributedPlaceholder = NSAttributedString(string: ExistingName, attributes: attributes)
+        $0.attributedPlaceholder = NSAttributedString(string: existingName, attributes: attributes)
         $0.autocapitalizationType = .none
         $0.layer.masksToBounds = true
         $0.leftView = UIView(frame: CGRect(x: 0, y: 0, width: 5, height: 0))
@@ -189,9 +192,16 @@ final class ProfileSettingViewController: BaseViewController {
         }
     }
     override func loadView() {
-        super.loadView()
-        
-        ExistingName = defaults.string(forKey: "currentUserName") ?? "유저명"
+         super.loadView()
+    }
+    func setProfileImage(name: String, imageUrl: String) async{
+        do {
+            print("프로필 이미지 세팅 작동")
+            self.existingName = name
+            self.profileImageView.image = try await NetworkManager.shared.fetchOneImage(withURL: imageUrl)
+        } catch {
+            print(error)
+        }
     }
     override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)

--- a/Flicker/Screens/ProfileSetting/ProfileSettingViewController.swift
+++ b/Flicker/Screens/ProfileSetting/ProfileSettingViewController.swift
@@ -44,9 +44,8 @@ final class ProfileSettingViewController: BaseViewController {
     private let profileLabelFirst = UILabel().makeBasicLabel(labelText: "자신을 보여줄 수 있는 간단한 프로필 사진을 보여주세요!", textColor: .textSubBlack, fontStyle: .caption1, fontWeight: .medium)
 
     private let profileLabelSecond = UILabel().makeBasicLabel(labelText: "프로필 사진은 작가와 모델의 매칭에 도움을 줍니다", textColor: .textSubBlack, fontStyle: .caption1, fontWeight: .medium)
+    
     private let nickNameLabel = UILabel().makeBasicLabel(labelText: "닉네임", textColor: .black, fontStyle: .title3, fontWeight: .bold)
-    private let isArtistLabel = UILabel().makeBasicLabel(labelText: "사진작가로 활동할 예정이신가요?", textColor: .black, fontStyle: .title3, fontWeight: .bold)
-    private let afterJoinLabel = UILabel().makeBasicLabel(labelText: "가입 후 마이프로필에서 작가등록을 하실 수 있어요!", textColor: .textSubBlack, fontStyle: .caption1, fontWeight: .medium)
 
     private lazy var nickNameField = UITextField().then {
         let attributes = [
@@ -63,24 +62,10 @@ final class ProfileSettingViewController: BaseViewController {
         $0.clipsToBounds = false
         $0.makeShadow(color: .black, opacity: 0.08, offset: CGSize(width: 0, height: 4), radius: 20)
     }
-
+    
     private let nickNameTextFieldClearButton = UIButton().then {
         $0.setImage(UIImage(systemName: "x.circle"), for: .normal)
         $0.tintColor = .textSubBlack
-    }
-
-    private let artistTrueButton = UIButton().then {
-        $0.setTitle("네", for: .normal)
-        $0.backgroundColor = .loginGray
-        $0.setTitleColor(.black, for: .normal)
-        $0.layer.cornerRadius = 10
-    }
-
-    private let artistFalseButton = UIButton().then {
-        $0.setTitle("아니오", for: .normal)
-        $0.backgroundColor = .loginGray
-        $0.setTitleColor(.black, for: .normal)
-        $0.layer.cornerRadius = 10
     }
 
     private let signUpButton = UIButton().then {
@@ -103,11 +88,8 @@ final class ProfileSettingViewController: BaseViewController {
         signUpButton.isEnabled = false
         nickNameTextFieldClearButton.isHidden = true
 
-        view.addSubviews(profileImageView, profileLabelFirst, profileLabelSecond, nickNameLabel, isArtistLabel, afterJoinLabel, nickNameField, artistTrueButton, artistFalseButton, signUpButton, nickNameTextFieldClearButton, nickNameDivider)
+        view.addSubviews(profileImageView, profileLabelFirst, profileLabelSecond, nickNameLabel, nickNameField, signUpButton, nickNameTextFieldClearButton, nickNameDivider)
 
-
-        artistTrueButton.addTarget(self, action: #selector(didTapArtistTrueButton), for: .touchUpInside)
-        artistFalseButton.addTarget(self, action: #selector(didTapArtistFalseButton), for: .touchUpInside)
         signUpButton.addTarget(self, action: #selector(didTapSignUpButton), for: .touchUpInside)
         nickNameTextFieldClearButton.addTarget(self, action: #selector(didTapClearButton), for: .touchUpInside)
 
@@ -151,28 +133,6 @@ final class ProfileSettingViewController: BaseViewController {
             $0.leading.trailing.equalToSuperview().inset(20)
         }
 
-        isArtistLabel.snp.makeConstraints {
-            $0.top.equalTo(nickNameField.snp.bottom).offset(20)
-            $0.leading.trailing.equalToSuperview().inset(20)
-        }
-
-        afterJoinLabel.snp.makeConstraints {
-            $0.top.equalTo(isArtistLabel.snp.bottom).offset(10)
-            $0.leading.trailing.equalToSuperview().inset(20)
-        }
-
-        artistTrueButton.snp.makeConstraints {
-            $0.top.equalTo(afterJoinLabel.snp.bottom).offset(10)
-            $0.leading.equalToSuperview().inset(20)
-            $0.trailing.equalTo(view.snp.centerX).inset(25 )
-        }
-
-        artistFalseButton.snp.makeConstraints {
-            $0.top.equalTo(afterJoinLabel.snp.bottom).offset(10)
-            $0.trailing.equalToSuperview().inset(20)
-            $0.leading.equalTo(view.snp.centerX).offset(10)
-        }
-
         signUpButton.snp.makeConstraints {
             $0.bottom.equalTo(view.safeAreaLayoutGuide.snp.bottom).inset(50)
             $0.leading.trailing.equalToSuperview().inset(20)
@@ -181,6 +141,7 @@ final class ProfileSettingViewController: BaseViewController {
     }
     override func loadView() {
          super.loadView()
+        existingName = defaults.string(forKey: "currentUserName") ?? "Error"
     }
     
     override func viewDidAppear(_ animated: Bool) {
@@ -207,37 +168,14 @@ final class ProfileSettingViewController: BaseViewController {
         self.present(imagePicker, animated: true)
     }
 
-    @objc private func didTapArtistTrueButton() {
-        artistTrueButton.backgroundColor = .mainPink
-        artistTrueButton.setTitleColor(.white, for: .normal)
-        artistFalseButton.backgroundColor = .loginGray
-        artistFalseButton.setTitleColor(.black, for: .normal)
-
-        if isNickNameWrite {
-            signUpButton.isEnabled = true
-            signUpButton.backgroundColor = .mainPink
-        }
-    }
-
-    @objc private func didTapArtistFalseButton() {
-        artistTrueButton.backgroundColor = .loginGray
-        artistTrueButton.setTitleColor(.black, for: .normal)
-        artistFalseButton.backgroundColor = .mainPink
-        artistFalseButton.setTitleColor(.white, for: .normal)
-
-        if isNickNameWrite {
-            signUpButton.isEnabled = true
-            signUpButton.backgroundColor = .mainPink
-        }
-    }
     //TODO: profileImage가 없을 경우 이미지 값을 SFSymbol에서 받으려고 하는데 그 값조차 옵셔널 값으로 인식함 그래서 일단 강제언래핑 해놓음
     @objc private func didTapSignUpButton() {
         let viewController = TabbarViewController()
         let fireBaseUser = Auth.auth().currentUser
         Task { [weak self] in
-            if let fireBaseUser = fireBaseUser {
-                let email = fireBaseUser.email
-            }
+//            if let fireBaseUser = fireBaseUser {
+//                let email = fireBaseUser.email
+//            }
             await FirebaseManager.shared.storeUserInformation(email: fireBaseUser?.email ?? "",
                                                               name: nickNameField.text ?? "",
                                                               profileImage: profileImageView.image ?? UIImage(systemName: "person")! )
@@ -257,6 +195,8 @@ extension ProfileSettingViewController : UIImagePickerControllerDelegate, UINavi
     override func textFieldDidEndEditing(_ textField: UITextField) {
         isNickNameWrite = true
         nickNameTextFieldClearButton.isHidden = false
+        signUpButton.isEnabled = true
+        signUpButton.backgroundColor = .mainPink
     }
 
     func imagePickerController(_ picker: UIImagePickerController, didFinishPickingMediaWithInfo info: [UIImagePickerController.InfoKey : Any]) {

--- a/Flicker/Screens/ProfileSetting/ProfileSettingViewController.swift
+++ b/Flicker/Screens/ProfileSetting/ProfileSettingViewController.swift
@@ -17,13 +17,13 @@ import Firebase
 final class ProfileSettingViewController: BaseViewController {
     private var isNickNameWrite = false
     private let defaults = UserDefaults.standard
-    var existingName: String = ""
+    var currentUserName: String = ""
     private lazy var imagePicker = UIImagePickerController().then {
         $0.sourceType = .photoLibrary
         $0.allowsEditing = true
         $0.delegate = self
     }
-
+    
     lazy var profileImageView = UIImageView().then {
         $0.image = UIImage(named: "DefaultProfile")
         $0.backgroundColor = .loginGray
@@ -32,7 +32,7 @@ final class ProfileSettingViewController: BaseViewController {
         $0.isUserInteractionEnabled = true
         $0.addGestureRecognizer(UITapGestureRecognizer(target: self, action: #selector(selectButtonTouched)))
     }
-
+    
     private func labelTemplate(labelText: String, textColor: UIColor ,fontStyle: UIFont.TextStyle, fontWeight: UIFont.Weight) -> UILabel {
         let label = UILabel().then {
             $0.text = labelText
@@ -42,19 +42,19 @@ final class ProfileSettingViewController: BaseViewController {
         return label
     }
     private let profileLabelFirst = UILabel().makeBasicLabel(labelText: "자신을 보여줄 수 있는 간단한 프로필 사진을 보여주세요!", textColor: .textSubBlack, fontStyle: .caption1, fontWeight: .medium)
-
+    
     private let profileLabelSecond = UILabel().makeBasicLabel(labelText: "프로필 사진은 작가와 모델의 매칭에 도움을 줍니다", textColor: .textSubBlack, fontStyle: .caption1, fontWeight: .medium)
     
     private let nickNameLabel = UILabel().makeBasicLabel(labelText: "닉네임", textColor: .black, fontStyle: .title3, fontWeight: .bold)
-
+    
     private lazy var nickNameField = UITextField().then {
         let attributes = [
             NSAttributedString.Key.foregroundColor : UIColor.textSubBlack,
             NSAttributedString.Key.font : UIFont.systemFont(ofSize: 17, weight: .light)
         ]
-
+        
         $0.backgroundColor = .clear
-        $0.attributedPlaceholder = NSAttributedString(string: existingName, attributes: attributes)
+        $0.attributedPlaceholder = NSAttributedString(string: currentUserName, attributes: attributes)
         $0.autocapitalizationType = .none
         $0.layer.masksToBounds = true
         $0.leftView = UIView(frame: CGRect(x: 0, y: 0, width: 5, height: 0))
@@ -67,72 +67,72 @@ final class ProfileSettingViewController: BaseViewController {
         $0.setImage(UIImage(systemName: "x.circle"), for: .normal)
         $0.tintColor = .textSubBlack
     }
-
+    
     private let signUpButton = UIButton().then {
         $0.backgroundColor = .loginGray
         $0.setTitleColor(.white, for: .normal)
         $0.setTitle("수정 완료", for: .normal)
         $0.layer.cornerRadius = 15
     }
-
+    
     private let navigationDivider = UIView().then {
         $0.backgroundColor = .loginGray
     }
-
+    
     private let nickNameDivider = UIView().then {
         $0.backgroundColor = .loginGray
     }
-
+    
     override func render() {
         nickNameField.delegate = self
         signUpButton.isEnabled = false
         nickNameTextFieldClearButton.isHidden = true
-
+        
         view.addSubviews(profileImageView, profileLabelFirst, profileLabelSecond, nickNameLabel, nickNameField, signUpButton, nickNameTextFieldClearButton, nickNameDivider)
-
+        
         signUpButton.addTarget(self, action: #selector(didTapSignUpButton), for: .touchUpInside)
         nickNameTextFieldClearButton.addTarget(self, action: #selector(didTapClearButton), for: .touchUpInside)
-
-
+        
+        
         profileImageView.snp.makeConstraints {
             $0.top.equalTo(view.safeAreaLayoutGuide.snp.top).offset(60)
             $0.centerX.equalToSuperview()
             $0.width.height.equalTo(100)
         }
-
+        
         profileLabelFirst.snp.makeConstraints {
             $0.top.equalTo(profileImageView.snp.bottom).offset(30)
             $0.centerX.equalToSuperview()
         }
-
+        
         profileLabelSecond.snp.makeConstraints {
             $0.top.equalTo(profileLabelFirst.snp.bottom).offset(2)
             $0.centerX.equalToSuperview()
         }
-
+        
         nickNameLabel.snp.makeConstraints {
             $0.top.equalTo(profileLabelSecond.snp.bottom).offset(45)
             $0.leading.equalToSuperview().inset(20)
         }
-
+        
         nickNameField.snp.makeConstraints {
             $0.top.equalTo(nickNameLabel.snp.bottom).offset(10)
             $0.leading.equalToSuperview().inset(20)
             $0.trailing.equalToSuperview().inset(60)
         }
-
+        
         nickNameTextFieldClearButton.snp.makeConstraints {
             $0.centerY.equalTo(nickNameField.snp.centerY)
             $0.leading.equalTo(nickNameField.snp.trailing)
             $0.trailing.equalToSuperview().inset(30)
         }
-
+        
         nickNameDivider.snp.makeConstraints {
             $0.height.equalTo(1)
             $0.top.equalTo(nickNameField.snp.bottom).offset(5)
             $0.leading.trailing.equalToSuperview().inset(20)
         }
-
+        
         signUpButton.snp.makeConstraints {
             $0.bottom.equalTo(view.safeAreaLayoutGuide.snp.bottom).inset(50)
             $0.leading.trailing.equalToSuperview().inset(20)
@@ -140,8 +140,8 @@ final class ProfileSettingViewController: BaseViewController {
         }
     }
     override func loadView() {
-         super.loadView()
-        existingName = defaults.string(forKey: "currentUserName") ?? "Error"
+        super.loadView()
+        currentUserName = defaults.string(forKey: "currentUserName") ?? "Error"
     }
     
     override func viewDidAppear(_ animated: Bool) {
@@ -153,29 +153,26 @@ final class ProfileSettingViewController: BaseViewController {
         navigationController?.setNavigationBarHidden(false, animated: false)
         self.tabBarController?.tabBar.isHidden = true
     }
-
+    
     override func viewWillDisappear(_ animated: Bool) {
         super.viewWillDisappear(animated)
         navigationController?.setNavigationBarHidden(true, animated: false)
     }
-
+    
     override func setupNavigationBar() {
         super.setupNavigationBar()
         title = "프로필 수정"
     }
-
+    
     @objc private func selectButtonTouched(_ recognizer: UITapGestureRecognizer) {
         self.present(imagePicker, animated: true)
     }
-
+    
     //TODO: profileImage가 없을 경우 이미지 값을 SFSymbol에서 받으려고 하는데 그 값조차 옵셔널 값으로 인식함 그래서 일단 강제언래핑 해놓음
     @objc private func didTapSignUpButton() {
         let viewController = TabbarViewController()
         let fireBaseUser = Auth.auth().currentUser
         Task { [weak self] in
-//            if let fireBaseUser = fireBaseUser {
-//                let email = fireBaseUser.email
-//            }
             await FirebaseManager.shared.storeUserInformation(email: fireBaseUser?.email ?? "",
                                                               name: nickNameField.text ?? "",
                                                               profileImage: profileImageView.image ?? UIImage(systemName: "person")! )
@@ -184,25 +181,25 @@ final class ProfileSettingViewController: BaseViewController {
         }
         self.dismiss(animated: true, completion: nil)
     }
-
+    
     @objc private func didTapClearButton() {
         self.nickNameField.text = ""
     }
 }
 
 extension ProfileSettingViewController : UIImagePickerControllerDelegate, UINavigationControllerDelegate  {
-
+    
     override func textFieldDidEndEditing(_ textField: UITextField) {
         isNickNameWrite = true
         nickNameTextFieldClearButton.isHidden = false
         signUpButton.isEnabled = true
         signUpButton.backgroundColor = .mainPink
     }
-
+    
     func imagePickerController(_ picker: UIImagePickerController, didFinishPickingMediaWithInfo info: [UIImagePickerController.InfoKey : Any]) {
-
+        
         var newImage : UIImage? = nil // update 할 이미지
-
+        
         if let possibleImage = info[UIImagePickerController.InfoKey.editedImage] as? UIImage {
             newImage = possibleImage    // 수정된 이미지가 있을 경우
         } else if let possibleImage = info[UIImagePickerController.InfoKey.originalImage] as? UIImage {

--- a/Flicker/Screens/ProfileSetting/ProfileSettingViewController.swift
+++ b/Flicker/Screens/ProfileSetting/ProfileSettingViewController.swift
@@ -15,7 +15,8 @@ import FirebaseAuth
  */
 final class ProfileSettingViewController: BaseViewController {
     private var isNickNameWrite = false
-
+    private let defaults = UserDefaults.standard
+    private var ExistingName: String = ""
     private lazy var imagePicker = UIImagePickerController().then {
         $0.sourceType = .photoLibrary
         $0.allowsEditing = true
@@ -50,14 +51,14 @@ final class ProfileSettingViewController: BaseViewController {
     private let isArtistLabel = UILabel().makeBasicLabel(labelText: "사진작가로 활동할 예정이신가요?", textColor: .black, fontStyle: .title3, fontWeight: .bold)
     private let afterJoinLabel = UILabel().makeBasicLabel(labelText: "가입 후 마이프로필에서 작가등록을 하실 수 있어요!", textColor: .textSubBlack, fontStyle: .caption1, fontWeight: .medium)
 
-    private let nickNameField = UITextField().then {
+    private lazy var nickNameField = UITextField().then {
         let attributes = [
             NSAttributedString.Key.foregroundColor : UIColor.textSubBlack,
             NSAttributedString.Key.font : UIFont.systemFont(ofSize: 17, weight: .light)
         ]
 
         $0.backgroundColor = .clear
-        $0.attributedPlaceholder = NSAttributedString(string: "닉네임을 입력해 주세요!", attributes: attributes)
+        $0.attributedPlaceholder = NSAttributedString(string: ExistingName, attributes: attributes)
         $0.autocapitalizationType = .none
         $0.layer.masksToBounds = true
         $0.leftView = UIView(frame: CGRect(x: 0, y: 0, width: 5, height: 0))
@@ -187,7 +188,11 @@ final class ProfileSettingViewController: BaseViewController {
             $0.height.equalTo(50)
         }
     }
-
+    override func loadView() {
+        super.loadView()
+        
+        ExistingName = defaults.string(forKey: "currentUserName") ?? "유저명"
+    }
     override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
     }


### PR DESCRIPTION
## 🌁 배경
유저가 현재 프로필 세팅뷰를 이용 못 하고 있어 해당 기능을 개발했습니다.

## 👩‍💻 작업 내용 (Content)
- 유저는 이제 프로필세팅화면으로 넘어가면 그곳에서 자신의 프로필 이미지와 닉네임을 볼 수 있습니다.
- 수정이 가능하고 이는 파이어베이스 서버에 업로드 되며 유저 디폴츠로 추후 이용하기 편하게 저장됩니다.
- 이 시점에서는 회원가입 뷰에서 필요했던 아티스트로 활동할것인지에 대해 확인할 필요가 없습니다. 관련 UI 요소를 삭제했습니다.

## 📱 스크린샷

<p align="left">
  <img width="400" alt="스크린샷3" src="https://user-images.githubusercontent.com/47441965/203248200-eb8a5cb5-2159-4828-b7e5-05f1452ca6a6.png">
</p>


## ✅ 테스트방법
- UI는 올린 캡쳐 화면을 보시면 되고 기능은 직접 ProfileViewController에서 헤더 카드를 탭하여 변경해보시면 됩니다.

## 📣 PR & Issues
close #107 
