### PR TITLE
✨ ArtistTappedView 작가 정보 데이터 업데이트 기능 추가

### DIFF
--- a/Flicker/Global/Extensions/ArrayExtension.swift
+++ b/Flicker/Global/Extensions/ArrayExtension.swift
@@ -6,7 +6,7 @@
 //
 
 extension Array {
-    func stringByJoining(separator: String) -> String {
+    func joinString(separator: String) -> String {
         var result = ""
         for (idx, item) in self.enumerated() {
             result += "\(item)"

--- a/Flicker/Screens/Artist/ArtistTappedViewController.swift
+++ b/Flicker/Screens/Artist/ArtistTappedViewController.swift
@@ -121,6 +121,9 @@ final class ArtistTappedViewController: BaseViewController {
         tabBarController?.tabBar.isHidden = true
         statusBarBackGroundView.isHidden = true
         navigationBarSeperator.isHidden = true
+
+        mutualPayLabel.linesCornerRadius = 10
+        mutualPayLabel.skeletonTextLineHeight = SkeletonTextLineHeight.fixed(30)
     }
 
     override func setupNavigationBar() {

--- a/Flicker/Screens/Artist/ArtistTappedViewController.swift
+++ b/Flicker/Screens/Artist/ArtistTappedViewController.swift
@@ -80,7 +80,7 @@ final class ArtistTappedViewController: BaseViewController {
         $0.frame.size.height = 30
         $0.layer.cornerRadius = 15
         $0.backgroundColor = .white.withAlphaComponent(0.7)
-        $0.addTarget(self, action: #selector(didTapBackButton), for: .touchUpInside)
+        $0.addTarget(self, action: #selector(didTapCustomBackButton), for: .touchUpInside)
     }
 
     override func viewDidLoad() {
@@ -323,6 +323,14 @@ extension ArtistTappedViewController: UICollectionViewDelegateFlowLayout {
         return UIEdgeInsets(top: 5, left: 20, bottom: 0, right: 20)
     }
 }
+
+extension ArtistTappedViewController {
+    @objc func didTapCustomBackButton() {
+        self.navigationController?.isNavigationBarHidden = true
+        self.navigationController?.popViewController(animated: true)
+    }
+}
+
 
 //        //TODO: 공유하기 기능으로 출시 후 업데이트 예정
 //        let shareImageView = UIImageView().then {

--- a/Flicker/Screens/Artist/ArtistTappedViewController.swift
+++ b/Flicker/Screens/Artist/ArtistTappedViewController.swift
@@ -211,18 +211,10 @@ final class ArtistTappedViewController: BaseViewController {
             $0.width.equalToSuperview()
         }
 
-        // navigationBar 상단의 statusBar 자리를 UIView로 대체하여 조정
-        statusBarBackGroundView.translatesAutoresizingMaskIntoConstraints = false
-
-        statusBarBackGroundView.topAnchor.constraint(equalTo: view.topAnchor).isActive = true
-
-        statusBarBackGroundView.bottomAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor).isActive = true
-
-        statusBarBackGroundView.leadingAnchor.constraint(equalTo: view.leadingAnchor).isActive = true
-
-        statusBarBackGroundView.trailingAnchor.constraint(equalTo: view.trailingAnchor).isActive = true
-
-        statusBarBackGroundView.translatesAutoresizingMaskIntoConstraints = false
+        statusBarBackGroundView.snp.makeConstraints {
+            $0.top.leading.trailing.equalToSuperview()
+            $0.bottom.equalTo(view.safeAreaLayoutGuide.snp.top)
+        }
 
         navigationBarSeperator.snp.makeConstraints {
             $0.width.equalToSuperview()

--- a/Flicker/Screens/Artist/ArtistTappedViewController.swift
+++ b/Flicker/Screens/Artist/ArtistTappedViewController.swift
@@ -11,12 +11,11 @@ import SnapKit
 
 final class ArtistTappedViewController: BaseViewController {
 
-    // 넘겨주는 데이터
-    var artist: Artist?
+    lazy var artist: Artist = defaultArtistInfo
 
     private let networkManager = NetworkManager.shared
 
-    //    var artistInfo: Artist = Artist(regions: [], camera: "", lens: "", detailDescription: "", portfolioImageUrls: [])
+    private let defaultArtistInfo: Artist = Artist(regions: [], camera: "", lens: "", tags: [], detailDescription: "", portfolioImageUrls: [], userInfo: [:])
 
     private var imageList: [UIImage] = [UIImage(systemName: "questionmark.app")!, UIImage(systemName: "questionmark.app")!, UIImage(systemName: "questionmark.app")!]
 
@@ -166,8 +165,8 @@ final class ArtistTappedViewController: BaseViewController {
 
     private func fetchImages() async {
         do {
-            self.imageList = try await networkManager.fetchImages(withURLs: networkManager.portFolioImageList)
-            self.profileImage = try await networkManager.fetchOneImage(withURL: networkManager.portFolioImageList.first!)
+            self.imageList = try await networkManager.fetchImages(withURLs: artist.portfolioImageUrls)
+            self.profileImage = try await networkManager.fetchOneImage(withURL: UserDefaults.standard.string(forKey: "currentUserProfileImageUrl") ?? "")
             isDownLoaded = true
             self.collectionView.reloadData()
             self.collectionView.performBatchUpdates {
@@ -295,6 +294,7 @@ extension ArtistTappedViewController: UICollectionViewDataSource {
         //        headerView.resetArtistInfo(with: artistInfo)
         headerView.resetProfileImage(with: profileImage)
         headerView.resetPortfolioImage(with: thumnailImages)
+        headerView.resetArtistInfo(with: artist ?? defaultArtistInfo)
         return headerView
     }
 }

--- a/Flicker/Screens/Artist/ArtistTappedViewController.swift
+++ b/Flicker/Screens/Artist/ArtistTappedViewController.swift
@@ -4,21 +4,28 @@
 //
 //  Created by Jisu Jang on 2022/10/29.
 //
+import SkeletonView
 import UIKit
 import Then
 import SnapKit
 
 final class ArtistTappedViewController: BaseViewController {
-    
+
     // 넘겨주는 데이터
     var artist: Artist?
-    
+
     private let networkManager = NetworkManager.shared
-    
-    private var imageList: [UIImage] = []
-    
-    private var headerHeight: Int = 700
-    
+
+    //    var artistInfo: Artist = Artist(regions: [], camera: "", lens: "", detailDescription: "", portfolioImageUrls: [])
+
+    private var imageList: [UIImage] = [UIImage(systemName: "questionmark.app")!, UIImage(systemName: "questionmark.app")!, UIImage(systemName: "questionmark.app")!]
+
+    private var isDownLoaded: Bool = false
+
+    private var profileImage: UIImage = UIImage()
+
+    private var headerHeight: Int = 715
+
     private lazy var portfolioFlowLayout = UICollectionViewFlowLayout().then {
         let imageWidth = (UIScreen.main.bounds.width - 50)/3
         $0.itemSize = CGSize(width: imageWidth , height: imageWidth)
@@ -26,76 +33,96 @@ final class ArtistTappedViewController: BaseViewController {
         $0.minimumInteritemSpacing = 1
         $0.headerReferenceSize = CGSize(width: UIScreen.main.bounds.width, height: CGFloat(headerHeight))
     }
-    
-    private lazy var collectionView = UICollectionView(frame: .zero, collectionViewLayout: portfolioFlowLayout).then { $0.contentInsetAdjustmentBehavior = .never
+
+    private lazy var collectionView = UICollectionView(frame: .zero, collectionViewLayout: portfolioFlowLayout).then {
+        $0.register(ArtistPortfolioCell.self, forCellWithReuseIdentifier: ArtistPortfolioCell.className)
+
+        $0.register(HeaderCollectionReusableView.self, forSupplementaryViewOfKind: UICollectionView.elementKindSectionHeader, withReuseIdentifier: HeaderCollectionReusableView.className)
+        $0.contentInsetAdjustmentBehavior = .never
+        $0.isSkeletonable = true
+        $0.skeletonCornerRadius = 5
     }
-    
+
     private let bottomBackgroundView = {
         let UIView = UIView()
         UIView.backgroundColor = .white
+        UIView.isSkeletonable = true
         return UIView
     }()
-    
+
     private let counselingButton = UIButton().then {
+        $0.skeletonCornerRadius = 15
         $0.setTitle("문의하기", for: .normal)
         $0.titleLabel?.font = UIFont.preferredFont(forTextStyle: .callout, weight: .black)
         $0.setTitleColor(.white, for: .normal)
         $0.backgroundColor = .mainPink
         $0.layer.cornerRadius = 15
+        $0.isSkeletonable = true
     }
-    
-    private let mutualPayLabel = UILabel().makeBasicLabel(labelText: "상호 페이", textColor: .textSubBlack.withAlphaComponent(0.9), fontStyle: .title3, fontWeight: .bold)
-    
+
+    private let mutualPayLabel = UILabel().makeBasicLabel(labelText: "상호 페이", textColor: .textSubBlack.withAlphaComponent(0.9), fontStyle: .title3, fontWeight: .bold).then {
+        $0.skeletonCornerRadius = 5
+    }
+
     private let statusBarBackGroundView = UIView().then {
         $0.backgroundColor = .white
     }
-    
+
     private let navigationBarSeperator = UIView().then {
         $0.backgroundColor = .systemGray5
     }
-    
+
     private let bottomBarSeperator = UIView().then {
         $0.backgroundColor = .systemGray5
     }
-    
+
+    private lazy var backButton = BackButton().then {
+        $0.frame.size.width = 30
+        $0.frame.size.height = 30
+        $0.layer.cornerRadius = 15
+        $0.backgroundColor = .white.withAlphaComponent(0.7)
+        $0.addTarget(self, action: #selector(didTapBackButton), for: .touchUpInside)
+    }
+
     override func viewDidLoad() {
-        
         setDelegateAndDataSource()
-        
-        view.addSubviews(collectionView, statusBarBackGroundView, navigationBarSeperator, bottomBackgroundView, counselingButton, bottomBarSeperator)
-        
-        collectionView.register(ArtistPortfolioCell.self, forCellWithReuseIdentifier: ArtistPortfolioCell.className)
-        
-        collectionView.register(HeaderCollectionReusableView.self, forSupplementaryViewOfKind: UICollectionView.elementKindSectionHeader, withReuseIdentifier: HeaderCollectionReusableView.className)
-        
+
         Task {
-            await fetchPortfolioImages()
+            await fetchImages()
         }
-        
-        configUI()
+
         setupBackButton()
         setupNavigationBar()
+        render()
+        configUI()
     }
-    
+
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.001) {
+            self.showSkeletonView()
+        }
+    }
+
+    override func viewWillDisappear(_ animated: Bool) {
+        super.viewWillDisappear(animated)
+        navigationController?.navigationBar.backgroundColor = .clear
+        tabBarController?.tabBar.isHidden = false
+    }
+
     override func viewDidDisappear(_ animated: Bool) {
         super.viewDidDisappear(animated)
         statusBarBackGroundView.isHidden = true
         navigationBarSeperator.isHidden = true
         navigationController?.navigationBar.backgroundColor = .clear
     }
-    
-    override func viewWillDisappear(_ animated: Bool) {
-        super.viewWillDisappear(animated)
-        navigationController?.navigationBar.backgroundColor = .clear
-        tabBarController?.tabBar.isHidden = false
-    }
-    
+
     override func configUI() {
         tabBarController?.tabBar.isHidden = true
         statusBarBackGroundView.isHidden = true
         navigationBarSeperator.isHidden = true
     }
-    
+
     override func setupNavigationBar() {
         guard let navigationBar = navigationController?.navigationBar else { return }
         let appearance = UINavigationBarAppearance()
@@ -103,38 +130,46 @@ final class ArtistTappedViewController: BaseViewController {
         navigationBar.standardAppearance = appearance
         navigationBar.compactAppearance = appearance
         navigationBar.scrollEdgeAppearance = appearance
-        
-        //        //TODO: 공유하기 기능으로 출시 후 업데이트 예정
-        //        let shareImageView = UIImageView().then {
-        //            $0.image = UIImage(systemName: "square.and.arrow.up")
-        //            $0.frame = .init(origin: CGPoint(x: 0, y: 0), size: CGSize(width: 24, height: 24))
-        //            $0.tintColor = .black
-        //            $0.addGestureRecognizer(UITapGestureRecognizer(target: self, action: #selector(didTapShare(_:))))
-        //        }
-        //        navigationItem.rightBarButtonItem = makeBarButtonItem(with: shareImageView)
     }
-    
-    //TODO: 출시 후, 앱스토어 링크 넣을 예정
-    //    @objc private func didTapShare(_ sender: Any) {
-    //        guard let image = UIImage(named: "AppIcon") else { return }
-    //        let descriptionText = "나에게 맞는 작가님을 찾아 인생샷을 건져보세요"
-    //        let activityViewController = UIActivityViewController(activityItems: [image, descriptionText], applicationActivities: nil)
-    //        activityViewController.popoverPresentationController?.sourceView = self.view
-    //        self.present(activityViewController, animated: true, completion: nil)
-    //    }
-    
+
+    override func setupBackButton() {
+        let leftOffsetBackButton = removeBarButtonItemOffset(with: backButton, offsetX: 0)
+        let backButton = makeBarButtonItem(with: leftOffsetBackButton)
+        navigationItem.leftBarButtonItem = backButton
+    }
+
+    private func showSkeletonView() {
+        if !isDownLoaded {
+            let skeletonAnimation = SkeletonAnimationBuilder().makeSlidingAnimation(withDirection: .leftRight)
+
+            self.collectionView.showAnimatedGradientSkeleton(usingGradient: .init(colors: [.gray001, .lightGray]), animation: skeletonAnimation, transition: .none)
+
+            self.bottomBackgroundView.showAnimatedGradientSkeleton(usingGradient: .init(colors: [.gray001, .lightGray]), animation: skeletonAnimation, transition: .none)
+        }
+    }
+
+    private func stopSkeleton(with views: [UIView]) {
+        for view in views {
+            view.stopSkeletonAnimation()
+            view.hideSkeleton(reloadDataAfter: true, transition: .crossDissolve(0.5))
+        }
+    }
+
     private func setDelegateAndDataSource() {
         collectionView.delegate = self
         collectionView.dataSource = self
         collectionView.showsVerticalScrollIndicator = false
     }
-    
-    private func fetchPortfolioImages() async {
+
+    private func fetchImages() async {
         do {
             self.imageList = try await networkManager.fetchImages(withURLs: networkManager.portFolioImageList)
+            self.profileImage = try await networkManager.fetchOneImage(withURL: networkManager.portFolioImageList.first!)
+            isDownLoaded = true
             self.collectionView.reloadData()
             self.collectionView.performBatchUpdates {
                 self.resetHeaderViewSize()
+                self.stopSkeleton(with: [collectionView, bottomBackgroundView])
             }
         } catch {
             print(error)
@@ -146,73 +181,80 @@ final class ArtistTappedViewController: BaseViewController {
             navigationController?.navigationBar.backgroundColor = .white
             statusBarBackGroundView.isHidden = false
             navigationBarSeperator.isHidden = false
-
         } else {
             navigationController?.navigationBar.backgroundColor = .clear
             statusBarBackGroundView.isHidden = true
             navigationBarSeperator.isHidden = true
         }
     }
-    
+
     private func resetHeaderViewSize() {
         let layout = collectionView.collectionViewLayout as! UICollectionViewFlowLayout
         layout.headerReferenceSize = CGSize(width: UIScreen.main.bounds.width, height: CGFloat(headerHeight))
         self.collectionView.collectionViewLayout = layout
     }
-    
-    override func viewDidLayoutSubviews () {
-        super.viewDidLayoutSubviews()
+
+    override func render() {
+
+        view.addSubviews(collectionView, statusBarBackGroundView, navigationBarSeperator, bottomBackgroundView, counselingButton, bottomBarSeperator)
+
+        for subview in view.subviews {
+            subview.isSkeletonable = true
+        }
+
         collectionView.snp.makeConstraints {
             $0.top.equalToSuperview()
-            $0.bottom.equalTo(view.safeAreaLayoutGuide).inset(50)
+            $0.bottom.equalTo(view.snp.bottom).inset(view.frame.height / 10)
             $0.center.equalToSuperview()
             $0.width.equalToSuperview()
         }
-        
+
         // navigationBar 상단의 statusBar 자리를 UIView로 대체하여 조정
         statusBarBackGroundView.translatesAutoresizingMaskIntoConstraints = false
-        
+
         statusBarBackGroundView.topAnchor.constraint(equalTo: view.topAnchor).isActive = true
-        
+
         statusBarBackGroundView.bottomAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor).isActive = true
-        
+
         statusBarBackGroundView.leadingAnchor.constraint(equalTo: view.leadingAnchor).isActive = true
-        
+
         statusBarBackGroundView.trailingAnchor.constraint(equalTo: view.trailingAnchor).isActive = true
-        
+
         statusBarBackGroundView.translatesAutoresizingMaskIntoConstraints = false
-        
+
         navigationBarSeperator.snp.makeConstraints {
             $0.width.equalToSuperview()
             $0.height.equalTo(1)
         }
-        
-        guard let navigationBar = navigationController?.navigationBar else { return }
-        
-        navigationBarSeperator.topAnchor.constraint(equalTo: navigationBar.bottomAnchor).isActive = true
-        
+
+        navigationBarSeperator.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor).isActive = true
+
         // 하단의 문의하기 버튼이 있는 UIView
         bottomBackgroundView.addSubviews(counselingButton, mutualPayLabel)
-        
+
+        for subview in bottomBackgroundView.subviews {
+            subview.isSkeletonable = true
+        }
+
         bottomBackgroundView.snp.makeConstraints {
             $0.bottom.equalToSuperview()
             $0.centerX.equalToSuperview()
             $0.height.equalTo(view.frame.height / 10)
             $0.width.equalToSuperview()
         }
-        
+
         counselingButton.snp.makeConstraints {
             $0.trailing.equalToSuperview().inset(20)
             $0.top.equalToSuperview().inset(10)
             $0.height.equalTo(view.frame.height / 18)
             $0.width.equalTo(view.frame.width / 2.2)
         }
-        
+
         mutualPayLabel.snp.makeConstraints {
             $0.leading.equalToSuperview().inset(40)
             $0.centerY.equalTo(counselingButton)
         }
-        
+
         bottomBarSeperator.snp.makeConstraints {
             $0.width.equalToSuperview()
             $0.height.equalTo(1)
@@ -222,51 +264,51 @@ final class ArtistTappedViewController: BaseViewController {
 }
 
 extension ArtistTappedViewController: UICollectionViewDataSource {
-    
+
     // numberOfCell
     func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
         return imageList.count
     }
-    
+
     // ReusableCell setting + image loading
     func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath)
     -> UICollectionViewCell {
         let cell = collectionView.dequeueReusableCell(withReuseIdentifier: ArtistPortfolioCell.className, for: indexPath) as! ArtistPortfolioCell
         // 이미지 URL을 가진 response 배열
+        cell.isSkeletonable = true
         let image = imageList[indexPath.item]
         cell.image = image
         return cell
     }
-    
+
     // dequeheaderView, set headerHeight
     func collectionView(_ collectionView: UICollectionView, viewForSupplementaryElementOfKind kind: String, at indexPath: IndexPath) -> UICollectionReusableView {
         let headerView = collectionView.dequeueReusableSupplementaryView(ofKind: kind, withReuseIdentifier: HeaderCollectionReusableView.className, for: indexPath) as! HeaderCollectionReusableView
         headerHeight = Int(headerView.getTotalViewHeight())
 
         let thumnailImages = Array(imageList.prefix(4))
+        headerView.isSkeletonable = true
+        // TODO: 헤더뷰 데이터 업로드
+        //        headerView.resetArtistInfo(with: artistInfo)
+        headerView.resetProfileImage(with: profileImage)
         headerView.resetPortfolioImage(with: thumnailImages)
         return headerView
     }
 }
 
 extension ArtistTappedViewController: UICollectionViewDelegate {
-    
+
     func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
-        
         let cell = collectionView.cellForItem(at: indexPath) as! ArtistPortfolioCell
-        
         let viewController = ImageViewController()
         viewController.image = cell.imageView.image
         viewController.modalPresentationStyle = .fullScreen
         viewController.completion = {
-            self.statusBarBackGroundView.isHidden = false
-            self.navigationBarSeperator.isHidden = false
-            self.tabBarController?.tabBar.isHidden = true
             self.resetNavigationBarBackground()
+            self.tabBarController?.tabBar.isHidden = true
         }
         present(viewController, animated: false)
     }
-    
     // 스크롤시 네비게이션바 커스텀화
     func scrollViewDidScroll(_ scrollView: UIScrollView) {
         resetNavigationBarBackground()
@@ -274,8 +316,26 @@ extension ArtistTappedViewController: UICollectionViewDelegate {
 }
 
 extension ArtistTappedViewController: UICollectionViewDelegateFlowLayout {
-    
+
     func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, insetForSectionAt section: Int) -> UIEdgeInsets {
-        return UIEdgeInsets(top: 0, left: 20, bottom: 0, right: 20)
+        return UIEdgeInsets(top: 5, left: 20, bottom: 0, right: 20)
     }
 }
+
+//        //TODO: 공유하기 기능으로 출시 후 업데이트 예정
+//        let shareImageView = UIImageView().then {
+//            $0.image = UIImage(systemName: "square.and.arrow.up")
+//            $0.frame = .init(origin: CGPoint(x: 0, y: 0), size: CGSize(width: 24, height: 24))
+//            $0.tintColor = .black
+//            $0.addGestureRecognizer(UITapGestureRecognizer(target: self, action: #selector(didTapShare(_:))))
+//        }
+//        navigationItem.rightBarButtonItem = makeBarButtonItem(with: shareImageView)
+
+//TODO: 출시 후, 앱스토어 링크 넣을 예정
+//    @objc private func didTapShare(_ sender: Any) {
+//        guard let image = UIImage(named: "AppIcon") else { return }
+//        let descriptionText = "나에게 맞는 작가님을 찾아 인생샷을 건져보세요"
+//        let activityViewController = UIActivityViewController(activityItems: [image, descriptionText], applicationActivities: nil)
+//        activityViewController.popoverPresentationController?.sourceView = self.view
+//        self.present(activityViewController, animated: true, completion: nil)
+//    }

--- a/Flicker/Screens/Artist/ArtistTappedViewController.swift
+++ b/Flicker/Screens/Artist/ArtistTappedViewController.swift
@@ -23,7 +23,7 @@ final class ArtistTappedViewController: BaseViewController {
 
     private var profileImage: UIImage = UIImage()
 
-    private var headerHeight: Int = 715
+    private var headerHeight: Int = 750
 
     private lazy var portfolioFlowLayout = UICollectionViewFlowLayout().then {
         let imageWidth = (UIScreen.main.bounds.width - 50)/3

--- a/Flicker/Screens/Artist/ArtistTappedViewController.swift
+++ b/Flicker/Screens/Artist/ArtistTappedViewController.swift
@@ -17,7 +17,7 @@ final class ArtistTappedViewController: BaseViewController {
 
     private let defaultArtistInfo: Artist = Artist(regions: [], camera: "", lens: "", tags: [], detailDescription: "", portfolioImageUrls: [], userInfo: [:])
 
-    private var imageList: [UIImage] = [UIImage(systemName: "questionmark.app")!, UIImage(systemName: "questionmark.app")!, UIImage(systemName: "questionmark.app")!]
+    private var imageList: [UIImage] = [UIImage(), UIImage(), UIImage()]
 
     private var isDownLoaded: Bool = false
 
@@ -166,7 +166,7 @@ final class ArtistTappedViewController: BaseViewController {
     private func fetchImages() async {
         do {
             self.imageList = try await networkManager.fetchImages(withURLs: artist.portfolioImageUrls)
-            self.profileImage = try await networkManager.fetchOneImage(withURL: UserDefaults.standard.string(forKey: "currentUserProfileImageUrl") ?? "")
+            self.profileImage = try await networkManager.fetchOneImage(withURL: artist.userInfo["userProfileImageUrl"] ?? "")
             isDownLoaded = true
             self.collectionView.reloadData()
             self.collectionView.performBatchUpdates {
@@ -289,12 +289,11 @@ extension ArtistTappedViewController: UICollectionViewDataSource {
         headerHeight = Int(headerView.getTotalViewHeight())
 
         let thumnailImages = Array(imageList.prefix(4))
+
         headerView.isSkeletonable = true
-        // TODO: 헤더뷰 데이터 업로드
-        //        headerView.resetArtistInfo(with: artistInfo)
         headerView.resetProfileImage(with: profileImage)
         headerView.resetPortfolioImage(with: thumnailImages)
-        headerView.resetArtistInfo(with: artist ?? defaultArtistInfo)
+        headerView.resetArtistInfo(with: artist)
         return headerView
     }
 }

--- a/Flicker/Screens/Artist/HeaderCollectionReusableView.swift
+++ b/Flicker/Screens/Artist/HeaderCollectionReusableView.swift
@@ -276,6 +276,17 @@ final class HeaderCollectionReusableView: UICollectionReusableView {
         self.artistInformation.text = "#\(tagText)"
         self.bodyInfo.text = artistInfo.camera
         self.lensInfo.text = artistInfo.lens
+        self.setNumberOfPageControl(with: artistInfo.portfolioImageUrls.count)
+    }
+
+    private func setNumberOfPageControl(with number: Int) {
+        switch number {
+        case 0: self.pageControl.numberOfPages = 0
+        case 1: self.pageControl.numberOfPages = 1
+        case 2: self.pageControl.numberOfPages = 2
+        case 3: self.pageControl.numberOfPages = 3
+        default: self.pageControl.numberOfPages = 4
+        }
     }
 }
 

--- a/Flicker/Screens/Artist/HeaderCollectionReusableView.swift
+++ b/Flicker/Screens/Artist/HeaderCollectionReusableView.swift
@@ -271,6 +271,7 @@ final class HeaderCollectionReusableView: UICollectionReusableView {
     func resetArtistInfo(with artistInfo: Artist) {
         self.introductionTextView.text = artistInfo.detailDescription
         self.regionInfo.text = artistInfo.regions.stringByJoining(separator: ", ")
+        self.artistInformation.text = artistInfo.tags.stringByJoining(separator: ", ")
         self.bodyInfo.text = artistInfo.camera
         self.lensInfo.text = artistInfo.lens
     }

--- a/Flicker/Screens/Artist/HeaderCollectionReusableView.swift
+++ b/Flicker/Screens/Artist/HeaderCollectionReusableView.swift
@@ -272,7 +272,7 @@ final class HeaderCollectionReusableView: UICollectionReusableView {
         self.artistNickname.text = UserDefaults.standard.string(forKey: "currentUserName") ?? "슈글 작가님"
         self.introductionTextView.text = artistInfo.detailDescription
         self.regionInfo.text = artistInfo.regions.joinString(separator: ", ")
-        let tagText = artistInfo.tags.joinString(separator: " # ")
+        let tagText = artistInfo.tags.joinString(separator: " #")
         self.artistInformation.text = "#\(tagText)"
         self.bodyInfo.text = artistInfo.camera
         self.lensInfo.text = artistInfo.lens

--- a/Flicker/Screens/Artist/HeaderCollectionReusableView.swift
+++ b/Flicker/Screens/Artist/HeaderCollectionReusableView.swift
@@ -269,9 +269,11 @@ final class HeaderCollectionReusableView: UICollectionReusableView {
     }
 
     func resetArtistInfo(with artistInfo: Artist) {
+        self.artistNickname.text = UserDefaults.standard.string(forKey: "currentUserName") ?? "슈글 작가님"
         self.introductionTextView.text = artistInfo.detailDescription
-        self.regionInfo.text = artistInfo.regions.stringByJoining(separator: ", ")
-        self.artistInformation.text = artistInfo.tags.stringByJoining(separator: ", ")
+        self.regionInfo.text = artistInfo.regions.joinString(separator: ", ")
+        let tagText = artistInfo.tags.joinString(separator: " # ")
+        self.artistInformation.text = "#\(tagText)"
         self.bodyInfo.text = artistInfo.camera
         self.lensInfo.text = artistInfo.lens
     }

--- a/Flicker/Screens/Artist/HeaderCollectionReusableView.swift
+++ b/Flicker/Screens/Artist/HeaderCollectionReusableView.swift
@@ -128,6 +128,7 @@ final class HeaderCollectionReusableView: UICollectionReusableView {
         lensInfo.linesCornerRadius = 5
         introductionLabel.linesCornerRadius = 5
         artistInformation.linesCornerRadius = 5
+        introductionTextView.linesCornerRadius = 5
     }
 
     override func layoutSubviews () {


### PR DESCRIPTION
## 🌁 배경
MainView에서 데이터 로드 작업이 끝나고 이를 넘겨받아 작가 디테일뷰의 정보를 업데이트하는 기능이 필요해졌습니다. 이와 관련된 코드 작업을 수행합니다.

## 👩‍💻 작업 내용 (Content)
- [x] 전달받은 작가 정보로 작가 collectionView 업데이트
- [x] 스켈레톤 관련 UI 일부 수정
- [x] 포트폴리오 이미지 개수에 따른 작가 디테일뷰의 페이지 컨트롤러 숫자 변경 코드 추가

#### 메인뷰와 작가디테일뷰를 왔다갔다할 때 발생하는 네비게이션바 생성, 없어짐 문제는 메인뷰컨과의 충돌을 고려해서 아직 수정하지않았습니다.

코비와 공통된 부분을 작업하다가 머지 과정에서 이전에 머지했었던 파일하나가 누락되었습니다. 그래서 이전 코드를 복붙해서 작가 디테일뷰는 PR과 비슷한 부분이 많습니다. 바뀐 부분 위주로 코멘트를 달아두었습니다
## 📱 스크린샷
![Simulator Screen Recording - iPhone 14 - 2022-11-22 at 17 23 38](https://user-images.githubusercontent.com/103009135/203262820-618a9fa4-4996-46c7-98c9-44feff64f977.gif)

## 📣 PR & Issues
#113 