### PR TITLE
⚡️ 이미지 리터럴 추가 및 회원가입할 때 기본 이미지 수정

### DIFF
--- a/Flicker/Global/Literal/ImageLiteral.swift
+++ b/Flicker/Global/Literal/ImageLiteral.swift
@@ -26,6 +26,7 @@ enum ImageLiteral {
     
     // MARK: - icon
     static var appLogo: UIImage { .load(name: "logo") }
+    static var defaultProfile: UIImage { .load(name: "DefaultProfile")}
 }
 
 extension UIImage {

--- a/Flicker/Screens/SignUp/LoginProfileViewController.swift
+++ b/Flicker/Screens/SignUp/LoginProfileViewController.swift
@@ -265,7 +265,7 @@ final class LoginProfileViewController: BaseViewController {
                 await FirebaseManager.shared.createNewAccount(email: authEmail, password: authPassword)
                 await FirebaseManager.shared.storeUserInformation(email: authEmail,
                                                                   name: nickNameField.text ?? "",
-                                                                  profileImage: profileImageView.image ?? UIImage(systemName: "person")! )
+                                                                  profileImage: profileImageView.image ?? ImageLiteral.defaultProfile )
                 await CurrentUserDataManager.shared.saveUserDefault()
                 self?.navigationController?.pushViewController(viewController, animated: true)
             }
@@ -275,7 +275,7 @@ final class LoginProfileViewController: BaseViewController {
                 guard let fireBaseUser = fireBaseUser else { return }
                 await FirebaseManager.shared.storeUserInformation(email: fireBaseUser.email ?? "",
                                                                   name: nickNameField.text ?? "",
-                                                                  profileImage: profileImageView.image ?? UIImage(systemName: "person")! )
+                                                                  profileImage: profileImageView.image ?? ImageLiteral.defaultProfile )
                 await CurrentUserDataManager.shared.saveUserDefault()
                 self?.navigationController?.pushViewController(viewController, animated: true)
             }


### PR DESCRIPTION
## 🌁 배경
- 기본 프로필이미지를 Asset에 들어가 있는 사진으로 변경했습니다.

## 👩‍💻 작업 내용 (Content)
- 이미지 리터럴에 Asset에 있는 사진 추가

- SFSymbol에서 Asset값으로 수정