### PR TITLE
🐛 아티스트탭뷰를 왔다갔다 할 때 생기는 오류를 수정

### DIFF
--- a/Flicker/Screens/Artist/ArtistTappedViewController.swift
+++ b/Flicker/Screens/Artist/ArtistTappedViewController.swift
@@ -106,11 +106,15 @@ final class ArtistTappedViewController: BaseViewController {
 //        }
 //    }
 
-//    override func viewWillDisappear(_ animated: Bool) {
-//        super.viewWillDisappear(animated)
-//        navigationController?.navigationBar.backgroundColor = .clear
-//        tabBarController?.tabBar.isHidden = false
-//    }
+    override func viewWillDisappear(_ animated: Bool) {
+        super.viewWillDisappear(animated)
+        navigationController?.navigationBar.backgroundColor = .clear
+        tabBarController?.tabBar.isHidden = false
+    }
+    
+    override func viewWillAppear(_ animated: Bool) {
+        tabBarController?.tabBar.isHidden = true
+    }
 //
 //    override func viewDidDisappear(_ animated: Bool) {
 //        super.viewDidDisappear(animated)

--- a/Flicker/Screens/Artist/ArtistTappedViewController.swift
+++ b/Flicker/Screens/Artist/ArtistTappedViewController.swift
@@ -87,38 +87,41 @@ final class ArtistTappedViewController: BaseViewController {
         render()
         configUI()
         setDelegateAndDataSource()
+        setupBackButton()
+        setupNavigationBar()
 
         Task {
             await fetchImages()
-        }
-
-        setupBackButton()
-        setupNavigationBar()
-        
-    }
-
-    override func viewWillAppear(_ animated: Bool) {
-        super.viewWillAppear(animated)
-        DispatchQueue.main.asyncAfter(deadline: .now() + 0.001) {
-            self.showSkeletonView()
+            
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.001) {
+                self.showSkeletonView()
+            }
         }
     }
 
-    override func viewWillDisappear(_ animated: Bool) {
-        super.viewWillDisappear(animated)
-        navigationController?.navigationBar.backgroundColor = .clear
-        tabBarController?.tabBar.isHidden = false
-    }
+//    override func viewWillAppear(_ animated: Bool) {
+//        super.viewWillAppear(animated)
+//        DispatchQueue.main.asyncAfter(deadline: .now() + 0.001) {
+//            self.showSkeletonView()
+//        }
+//    }
 
-    override func viewDidDisappear(_ animated: Bool) {
-        super.viewDidDisappear(animated)
-        statusBarBackGroundView.isHidden = true
-        navigationBarSeperator.isHidden = true
-        navigationController?.navigationBar.backgroundColor = .clear
-    }
+//    override func viewWillDisappear(_ animated: Bool) {
+//        super.viewWillDisappear(animated)
+//        navigationController?.navigationBar.backgroundColor = .clear
+//        tabBarController?.tabBar.isHidden = false
+//    }
+//
+//    override func viewDidDisappear(_ animated: Bool) {
+//        super.viewDidDisappear(animated)
+//        statusBarBackGroundView.isHidden = true
+//        navigationBarSeperator.isHidden = true
+//        navigationController?.navigationBar.backgroundColor = .clear
+//    }
 
     override func configUI() {
         tabBarController?.tabBar.isHidden = true
+        navigationController?.isNavigationBarHidden = false
         statusBarBackGroundView.isHidden = true
         navigationBarSeperator.isHidden = true
 
@@ -304,10 +307,10 @@ extension ArtistTappedViewController: UICollectionViewDelegate {
         let viewController = ImageViewController()
         viewController.image = cell.imageView.image
         viewController.modalPresentationStyle = .fullScreen
-        viewController.completion = {
-            self.resetNavigationBarBackground()
-            self.tabBarController?.tabBar.isHidden = true
-        }
+//        viewController.completion = {
+//            self.resetNavigationBarBackground()
+//            self.tabBarController?.tabBar.isHidden = true
+//        }
         present(viewController, animated: false)
     }
     // 스크롤시 네비게이션바 커스텀화

--- a/Flicker/Screens/Artist/HeaderCollectionReusableView.swift
+++ b/Flicker/Screens/Artist/HeaderCollectionReusableView.swift
@@ -269,7 +269,7 @@ final class HeaderCollectionReusableView: UICollectionReusableView {
     }
 
     func resetArtistInfo(with artistInfo: Artist) {
-        self.artistNickname.text = UserDefaults.standard.string(forKey: "userName") ?? "슈글 작가님"
+        self.artistNickname.text = artistInfo.userInfo["userName"]
         self.introductionTextView.text = artistInfo.detailDescription
         self.regionInfo.text = artistInfo.regions.joinString(separator: ", ")
         let tagText = artistInfo.tags.joinString(separator: " #")

--- a/Flicker/Screens/Chat/ChatViewController.swift
+++ b/Flicker/Screens/Chat/ChatViewController.swift
@@ -55,10 +55,12 @@ final class ChatViewController: BaseViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         
-        tabBarController?.tabBar.isHidden = true
-        
         hidekeyboardWhenTappedAroundExceptSendView()
         fetchData()
+    }
+    
+    override func viewWillAppear(_ animated: Bool) {
+        tabBarController?.tabBar.isHidden = true
     }
     
     override func viewWillDisappear(_ animated: Bool) {

--- a/Flicker/Screens/Main/MainViewController.swift
+++ b/Flicker/Screens/Main/MainViewController.swift
@@ -207,7 +207,6 @@ extension MainViewController: UICollectionViewDataSource, UICollectionViewDelega
         let artist = artists[indexPath.item] // 선택한 아티스트 데이터
         let vc = ArtistTappedViewController()
         vc.artist = artist
-        navigationController?.isNavigationBarHidden = false
         navigationController?.pushViewController(vc, animated: true)
     }
 }


### PR DESCRIPTION
## 🌁 배경
기존에 아티스트탭뷰를 들어갔다가 나오면, 상단 네비바와 탭바가 깜빡거리거나 생기는것이 예상치 못한 경우가 있어서 수정했습니다.
- 작가 상세뷰에서 문의하기를 눌렀을 때, 채팅방의 탭뷰가 안사라졌었습니다.
- 메인뷰에서 작가상세뷰로 넘어갈 때, 네비바가 깜빡거렸습니다.
- 작가상세뷰에서 메인뷰로 돌아갈 때, 네비바가 가끔씩 생겼습니다.

## 👩‍💻 작업 내용 (Content)
- 스켈레톤 UI를 넣으려고 무리하다가, 네비바와 탭바가 사라지는 주기를 잘못 골랐던 것 같습니다.
- 기존에 있던 코드를 잠시 주석처리하였습니다.

## 📱 스크린샷


https://user-images.githubusercontent.com/57849386/203318881-ef76fb2e-96a9-4fae-9cd1-2942ef3c2a37.mp4



## ✅ 테스트방법

## 📣 PR & Issues
- closed #131 

## 📬 참고문서, 레퍼런스

