### PR TITLE
🐛 🚑 네비게이션 바 관련 버그 & 로그아웃 후 애플로그인 시 프로필입력 창으로 가는 버그 & 로그아웃 후 애플로그인할시 Userdefault에 저장하지 않던 오류 수정

### DIFF
--- a/Flicker/Screens/Login/LoginViewController.swift
+++ b/Flicker/Screens/Login/LoginViewController.swift
@@ -293,8 +293,15 @@ extension LogInViewController: ASAuthorizationControllerDelegate, ASAuthorizatio
 
             Auth.auth().signIn(with: credential) { (authDataResult, error) in
                 guard (authDataResult?.user) != nil else { return }
-                self.goProfile()
-                LoginManager.shared.currentAppleIdToken = idTokenString
+                Task { [weak self] in
+                    if (await FirebaseManager.shared.getUser()) != nil {
+                        LoginManager.shared.currentAppleIdToken = idTokenString
+                        self?.goHome()
+                    } else {
+                        LoginManager.shared.currentAppleIdToken = idTokenString
+                        self?.goProfile()
+                    }
+                }
 
                 if error != nil {
                     print(error?.localizedDescription ?? "error" as Any)

--- a/Flicker/Screens/Login/LoginViewController.swift
+++ b/Flicker/Screens/Login/LoginViewController.swift
@@ -204,6 +204,11 @@ final class LogInViewController: BaseViewController {
         super.viewDidAppear(animated)
     }
 
+    override func viewWillDisappear(_ animated: Bool) {
+        super.viewWillDisappear(animated)
+        navigationController?.setNavigationBarHidden(true, animated: false)
+    }
+    
     private func goHome() {
         let viewController = TabbarViewController()
         let navigationController = UINavigationController(rootViewController: viewController)

--- a/Flicker/Screens/Login/LoginViewController.swift
+++ b/Flicker/Screens/Login/LoginViewController.swift
@@ -37,7 +37,7 @@ final class LogInViewController: BaseViewController {
         $0.font = UIFont(name: "TsukimiRounded-Bold", size: 15)
         $0.textColor = .textMainBlack
         $0.textAlignment = .center
-        $0.text = "국내 최초의 지역 기반 사진활영 플랫폼 슈글!"
+        $0.text = "국내 최초의 지역 기반 사진촬영 플랫폼 슈글!"
     }
 
     private let loginNormalLabel = UILabel().then {
@@ -296,6 +296,7 @@ extension LogInViewController: ASAuthorizationControllerDelegate, ASAuthorizatio
                 Task { [weak self] in
                     if (await FirebaseManager.shared.getUser()) != nil {
                         LoginManager.shared.currentAppleIdToken = idTokenString
+                        await CurrentUserDataManager.shared.saveUserDefault()
                         self?.goHome()
                     } else {
                         LoginManager.shared.currentAppleIdToken = idTokenString

--- a/Flicker/Screens/Main/MainViewController.swift
+++ b/Flicker/Screens/Main/MainViewController.swift
@@ -71,6 +71,16 @@ final class MainViewController: BaseViewController {
         super.viewDidLoad()
         loadData()
     }
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        navigationController?.setNavigationBarHidden(true, animated: false)
+    }
+
+    override func viewWillDisappear(_ animated: Bool) {
+        super.viewWillDisappear(animated)
+        navigationController?.setNavigationBarHidden(true, animated: false)
+    }
+
     
     override func render() {
         view.addSubviews(appTitleLabel, regionTagButton, emptyThumnailView, listCollectionView, emptyThumnailView)

--- a/Flicker/Screens/Profile/ProfileViewController.swift
+++ b/Flicker/Screens/Profile/ProfileViewController.swift
@@ -34,7 +34,8 @@ final class ProfileViewController: EmailViewController {
     }
     
     override func viewWillAppear(_ animated: Bool) {
-        navigationController?.setNavigationBarHidden(true, animated: true)
+        super.viewWillAppear(animated)
+        navigationController?.setNavigationBarHidden(true, animated: false)
         tabBarController?.tabBar.isHidden = false
     }
 

--- a/Flicker/Screens/Tabbar/TabbarViewController.swift
+++ b/Flicker/Screens/Tabbar/TabbarViewController.swift
@@ -35,4 +35,10 @@ final class TabbarViewController: UITabBarController {
         tabBar.backgroundColor = .white
         setViewControllers([mainViewController, searchViewController, messageViewController, profileViewController], animated: true)
     }
+
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        navigationController?.setNavigationBarHidden(true, animated: false)
+    }
+
 }


### PR DESCRIPTION
## 🌁 배경
- 로그인 과정에서 생기는 버그들을 찾아서 수정을 했습니다.

## 👩‍💻 작업 내용 (Content)
- 회원가입이 아닌 로그인으로 앱을 들어갔을 경우, 네비게이션 바가 생기는 문제를 해결했습니다. tabbarVC가 willAppear가 될때 navigationBar를 hidden해줬습니다.

- 로그아웃 후 애플로그인을 다시 할때 서버에서 값을 불러와 값이 존재하면 바로 메인뷰로 가도록 설정했습니다.

- 또한 로그아웃 후 애플로그인을 다시 할때 유저디폴트가 삭제됬음에도 다시 저장하지 않아 프로필이 뜨지않던 오류를 수정했습니다.

## 📣 PR & Issues
- closed #133 