### PR TITLE
✨ 세로모드로 고정하도록 설정을 했습니다.

### DIFF
--- a/Flicker/Global/Supports/AppDelegate.swift
+++ b/Flicker/Global/Supports/AppDelegate.swift
@@ -17,6 +17,11 @@ class AppDelegate: UIResponder, UIApplicationDelegate, MessagingDelegate, UNUser
     var window: UIWindow?
     var userToken: String = ""
 
+    //세로방향 고정하는 함수
+    func application(_ application: UIApplication, supportedInterfaceOrientationsFor window: UIWindow?) -> UIInterfaceOrientationMask {
+        return UIInterfaceOrientationMask.portrait
+    }
+
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
 
         FirebaseApp.configure()


### PR DESCRIPTION
## 🌁 배경
-  가로모드의 사용은 우리의 앱과 맞지 않고 설령 지금 한다고 하더라도 앱 출시를 위해 달리는 상황에서 소요가 크다고 생각해 우선은 세로모드로 고정을 하는 코드를 추가합니다.

## 👩‍💻 작업 내용 (Content)
- appdelegate에 화면이 안돌아가도록 하는 코드를 추가했습니다.

## ✅ 테스트방법
- 화면회전 키시고 휴대폰 돌리시면 됩니다.

## 📣 PR & Issues
- closed #125

