### PR TITLE
🐛 iOS 최소 지원버전에 맞게 모달을 커스텀했습니다.

### DIFF
--- a/Flicker/Global/UIComponent/PresentationController.swift
+++ b/Flicker/Global/UIComponent/PresentationController.swift
@@ -1,0 +1,71 @@
+//
+//  PresentationController.swift
+//  Flicker
+//
+//  Created by COBY_PRO on 2022/11/22.
+//
+
+import UIKit
+
+class PresentationController: UIPresentationController {
+
+  let blurEffectView: UIVisualEffectView!
+  var tapGestureRecognizer: UITapGestureRecognizer = UITapGestureRecognizer()
+  
+  override init(presentedViewController: UIViewController, presenting presentingViewController: UIViewController?) {
+      let blurEffect = UIBlurEffect(style: .dark)
+      blurEffectView = UIVisualEffectView(effect: blurEffect)
+      super.init(presentedViewController: presentedViewController, presenting: presentingViewController)
+      tapGestureRecognizer = UITapGestureRecognizer(target: self, action: #selector(dismissController))
+      blurEffectView.autoresizingMask = [.flexibleWidth, .flexibleHeight]
+      self.blurEffectView.isUserInteractionEnabled = true
+      self.blurEffectView.addGestureRecognizer(tapGestureRecognizer)
+  }
+  
+  override var frameOfPresentedViewInContainerView: CGRect {
+      CGRect(origin: CGPoint(x: 0, y: self.containerView!.frame.height * 0.4),
+             size: CGSize(width: self.containerView!.frame.width, height: self.containerView!.frame.height *
+              0.6))
+  }
+
+  override func presentationTransitionWillBegin() {
+      self.blurEffectView.alpha = 0
+      self.containerView?.addSubview(blurEffectView)
+      self.presentedViewController.transitionCoordinator?.animate(alongsideTransition: { (UIViewControllerTransitionCoordinatorContext) in
+          self.blurEffectView.alpha = 0.7
+      }, completion: { (UIViewControllerTransitionCoordinatorContext) in })
+  }
+  
+  override func dismissalTransitionWillBegin() {
+      self.presentedViewController.transitionCoordinator?.animate(alongsideTransition: { (UIViewControllerTransitionCoordinatorContext) in
+          self.blurEffectView.alpha = 0
+      }, completion: { (UIViewControllerTransitionCoordinatorContext) in
+          self.blurEffectView.removeFromSuperview()
+      })
+  }
+  
+  override func containerViewWillLayoutSubviews() {
+      super.containerViewWillLayoutSubviews()
+    presentedView!.roundCorners([.topLeft, .topRight], radius: 22)
+  }
+
+  override func containerViewDidLayoutSubviews() {
+      super.containerViewDidLayoutSubviews()
+      presentedView?.frame = frameOfPresentedViewInContainerView
+      blurEffectView.frame = containerView!.bounds
+  }
+
+  @objc func dismissController(){
+      self.presentedViewController.dismiss(animated: true, completion: nil)
+  }
+}
+
+extension UIView {
+  func roundCorners(_ corners: UIRectCorner, radius: CGFloat) {
+      let path = UIBezierPath(roundedRect: bounds, byRoundingCorners: corners,
+                              cornerRadii: CGSize(width: radius, height: radius))
+      let mask = CAShapeLayer()
+      mask.path = path.cgPath
+      layer.mask = mask
+  }
+}

--- a/Flicker/Screens/Main/MainViewController.swift
+++ b/Flicker/Screens/Main/MainViewController.swift
@@ -171,8 +171,8 @@ final class MainViewController: BaseViewController {
     
     @objc private func didTapRegionTag() {
         let vc = RegionViewController()
-        vc.modalPresentationStyle = .pageSheet
-        vc.sheetPresentationController?.detents = [.medium()]
+        vc.modalPresentationStyle = .custom
+        vc.transitioningDelegate = self
         
         present(vc, animated: true, completion: nil)
     }
@@ -223,5 +223,11 @@ extension MainViewController {
     
     private func didScrollToBottom() {
         continueData()
+    }
+}
+
+extension MainViewController: UIViewControllerTransitioningDelegate {
+    func presentationController(forPresented presented: UIViewController, presenting: UIViewController?, source: UIViewController) -> UIPresentationController? {
+        PresentationController(presentedViewController: presented, presenting: presenting)
     }
 }


### PR DESCRIPTION
## 🌁 배경
- iOS 15 미만 버전에서는, 하프 모달을 직접 커스텀해서 만들어야 합니다.

## 👩‍💻 작업 내용 (Content)
- 하프 모달을 커스텀한 PresentationController을 생성했습니다.

## 📱 스크린샷

https://user-images.githubusercontent.com/57849386/203344876-3da4f290-1328-4e14-943a-e0b7f7b495d0.mp4


## ✅ 테스트방법
- PR리뷰어가 변경사항을 확인할 수 있는 방법을 서술합니다.

## 📣 PR & Issues
- closed #99

## 📬 참고문서, 레퍼런스
https://stackoverflow.com/questions/42106980/how-to-present-a-viewcontroller-on-half-screen
