### PR TITLE
🐛 ArtisTappedView(= 작가디테일뷰) 네비게이션바 관련 버그 수정

### DIFF
--- a/Flicker/Screens/Artist/ArtistPortfolioCell.swift
+++ b/Flicker/Screens/Artist/ArtistPortfolioCell.swift
@@ -11,7 +11,7 @@ import SkeletonView
 final class ArtistPortfolioCell: UICollectionViewCell {
 
     let imageView: UIImageView = UIImageView(frame: .zero).then {
-        $0.contentMode = .scaleToFill
+        $0.contentMode = .scaleAspectFill
         $0.clipsToBounds = true
         $0.isSkeletonable = true
     }

--- a/Flicker/Screens/Artist/ArtistTappedViewController.swift
+++ b/Flicker/Screens/Artist/ArtistTappedViewController.swift
@@ -56,6 +56,7 @@ final class ArtistTappedViewController: BaseViewController {
         $0.backgroundColor = .mainPink
         $0.layer.cornerRadius = 15
         $0.isSkeletonable = true
+        $0.skeletonCornerRadius = 15
         $0.addTarget(self, action: #selector(didTapCounselingButton), for: .touchUpInside)
     }
 
@@ -87,8 +88,6 @@ final class ArtistTappedViewController: BaseViewController {
         render()
         configUI()
         setDelegateAndDataSource()
-        setupBackButton()
-        setupNavigationBar()
 
         Task {
             await fetchImages()
@@ -98,30 +97,27 @@ final class ArtistTappedViewController: BaseViewController {
             }
         }
     }
-
-//    override func viewWillAppear(_ animated: Bool) {
-//        super.viewWillAppear(animated)
-//        DispatchQueue.main.asyncAfter(deadline: .now() + 0.001) {
-//            self.showSkeletonView()
-//        }
-//    }
-
+    
+    override func viewWillAppear(_ animated: Bool) {
+        setupBackButton()
+        setupNavigationBar()
+        tabBarController?.tabBar.isHidden = true
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.001) {
+            self.showSkeletonView()
+        }
+    }
     override func viewWillDisappear(_ animated: Bool) {
         super.viewWillDisappear(animated)
         navigationController?.navigationBar.backgroundColor = .clear
         tabBarController?.tabBar.isHidden = false
     }
-    
-    override func viewWillAppear(_ animated: Bool) {
-        tabBarController?.tabBar.isHidden = true
-    }
-//
-//    override func viewDidDisappear(_ animated: Bool) {
-//        super.viewDidDisappear(animated)
-//        statusBarBackGroundView.isHidden = true
-//        navigationBarSeperator.isHidden = true
-//        navigationController?.navigationBar.backgroundColor = .clear
-//    }
+    // MARK: 추후 다른 뷰와 연결시 불필요하다고 판단되면 삭제 예정 (일단 주석)
+    //    override func viewDidDisappear(_ animated: Bool) {
+    //        super.viewDidDisappear(animated)
+    //        statusBarBackGroundView.isHidden = true
+    //        navigationBarSeperator.isHidden = true
+    //        navigationController?.navigationBar.backgroundColor = .clear
+    //    }
 
     override func configUI() {
         tabBarController?.tabBar.isHidden = true
@@ -310,10 +306,11 @@ extension ArtistTappedViewController: UICollectionViewDelegate {
         let viewController = ImageViewController()
         viewController.image = cell.imageView.image
         viewController.modalPresentationStyle = .fullScreen
-//        viewController.completion = {
-//            self.resetNavigationBarBackground()
-//            self.tabBarController?.tabBar.isHidden = true
-//        }
+        // MARK: 추후 다른 뷰와 연결시 불필요하다고 판단되면 삭제 예정 (일단 주석)
+        //        viewController.completion = {
+        //            self.resetNavigationBarBackground()
+        //            self.tabBarController?.tabBar.isHidden = true
+        //        }
         present(viewController, animated: false)
     }
     // 스크롤시 네비게이션바 커스텀화

--- a/Flicker/Screens/Artist/ArtistTappedViewController.swift
+++ b/Flicker/Screens/Artist/ArtistTappedViewController.swift
@@ -125,7 +125,6 @@ final class ArtistTappedViewController: BaseViewController {
 
     override func configUI() {
         tabBarController?.tabBar.isHidden = true
-        navigationController?.isNavigationBarHidden = false
         statusBarBackGroundView.isHidden = true
         navigationBarSeperator.isHidden = true
 

--- a/Flicker/Screens/Artist/ArtistTappedViewController.swift
+++ b/Flicker/Screens/Artist/ArtistTappedViewController.swift
@@ -258,12 +258,6 @@ final class ArtistTappedViewController: BaseViewController {
             $0.bottom.equalTo(bottomBackgroundView.snp.top)
         }
     }
-    
-    @objc func didTapCounselingButton() {
-        guard let userId = UserDefaults.standard.string(forKey: "userId") else { return }
-        let viewController = ChatViewController(name: artist.userInfo["userName"]!, fromId: userId, toId: artist.userInfo["userId"]!)
-        navigationController?.pushViewController(viewController, animated: true)
-    }
 }
 
 extension ArtistTappedViewController: UICollectionViewDataSource {
@@ -331,9 +325,13 @@ extension ArtistTappedViewController {
         self.navigationController?.isNavigationBarHidden = true
         self.navigationController?.popViewController(animated: true)
     }
+
+    @objc func didTapCounselingButton() {
+        guard let userId = UserDefaults.standard.string(forKey: "userId") else { return }
+        let viewController = ChatViewController(name: artist.userInfo["userName"]!, fromId: userId, toId: artist.userInfo["userId"]!)
+        navigationController?.pushViewController(viewController, animated: true)
+    }
 }
-
-
 //        //TODO: 공유하기 기능으로 출시 후 업데이트 예정
 //        let shareImageView = UIImageView().then {
 //            $0.image = UIImage(systemName: "square.and.arrow.up")

--- a/Flicker/Screens/Main/MainViewController.swift
+++ b/Flicker/Screens/Main/MainViewController.swift
@@ -78,7 +78,7 @@ final class MainViewController: BaseViewController {
 
     override func viewWillDisappear(_ animated: Bool) {
         super.viewWillDisappear(animated)
-        navigationController?.setNavigationBarHidden(true, animated: false)
+        navigationController?.setNavigationBarHidden(false, animated: false)
     }
 
     


### PR DESCRIPTION
## 🌁 배경
3차 버그테스팅에서 모든 뷰의 네비게이션 연결이 이루어졌습니다. 네비바의 중복 삽입, 의도치않은 숨겨짐 등의 버그가 있어서 하디와 코비가 이를 수정했습니다. 그 과정에서 제가 맡은 ArtistTappedView에서 뒤로가기 버튼 없어짐, 스켈레톤뷰 비활성화 등의 현상이 발생해서 이를 수정했습니다.

## 👩‍💻 작업 내용 (Content)

- [x] 작가디테일뷰에서 뒤로가기 버튼 없어짐 문제 
-> 메인뷰에서 뷰가 없어질 때도 네비게이션바를 없어지도록 하는 코드가 있었습니다. 이를 제거하여 해결했습니다.

- [x] 스켈레톤 뷰 복구
-> 메인뷰와 채팅뷰를 연결하는 과정을 원활히 하기 위해 작가 디테일뷰의 라이프사이클 관련 코드가 일부 수정되었습니다. 스켈레톤뷰를 활성화하는 코드가 주석처리되었는데 이를 다시 viewWillAppear에 추가하여 해결했습니다.

- [x] 작가 포트폴리오 이미지 비율 관련 코드 수정
-> 작가 디테일뷰 하단에는 작가가 등록한 이미지들이 콜렉션형태로 들어가는데, 그 이미지의 비율이 깨진다는 피드백이 있었습니다 원래는 ScaleToFill인데 scaleAspectFill 로 고쳐서 수정했습니다.

### ContentMode 옵션 정리
- AspectFill(비율 유지 O, 화면 꽉 채움 O, 이미지 잘림 O)
- AspectFit(비율 유지 O, 화면 꽉 채움 X, 이미지 잘림 X)
- ScaleToFill(비율 유지 X, 화면 꽉 채움 O, 이미지 잘림 X)

** AspectFit 옵션을 채택하면 이렇게 되버립니다.
<img width="200" alt="image" src="https://user-images.githubusercontent.com/103009135/203942896-01f90f33-3073-42b8-b223-18f550927dd4.png">

## 📱 스크린샷
![네비게이션테스트](https://user-images.githubusercontent.com/103009135/203941402-a475b107-ed43-4d57-b77a-79173746557f.gif)

## 📣 PR & Issues
#142 

## Reference
[이미지 contentMode 관련 정리](https://sujinnaljin.medium.com/ios-사진으로-보는-aspectfit-aspectfit-scaletofill-f41470d0191f)