### PR TITLE
🐛 메인화면 무한 스크롤 에러 해결

### DIFF
--- a/Flicker/Screens/Main/MainViewController.swift
+++ b/Flicker/Screens/Main/MainViewController.swift
@@ -30,6 +30,7 @@ final class MainViewController: BaseViewController {
     private var artists = [Artist]()
     
     private var cursor: DocumentSnapshot?
+    private var dataMayContinue = true
     
     // MARK: - property
     
@@ -156,7 +157,8 @@ final class MainViewController: BaseViewController {
     }
     
     private func continueData() {
-        guard let cursor = cursor else { return }
+        guard dataMayContinue, let cursor = cursor else { return }
+        dataMayContinue = false
         
         Task {
             if let result = await FirebaseManager.shared.continueArtist(regions: selectedRegions, cursor: cursor, pages: 10) {
@@ -167,6 +169,8 @@ final class MainViewController: BaseViewController {
             DispatchQueue.main.async {
                 self.listCollectionView.reloadData()
             }
+            
+            self.dataMayContinue = true
         }
     }
     


### PR DESCRIPTION
## 🌁 배경
메인화면에서 스크롤 시에, 데이터가 불규칙하게 불러오는 경향이 있었습니다.
데이터를 불러오는 동안, 화면을 그리는 작업과 데이터베이스를 추가적으로 불러오는 것을 겹치지 않게 하기 위해, Bool 변수를 추가하였습니다.

## 👩‍💻 작업 내용 (Content)
- dataMayContinue 변수를 추가해서, 불규칙한 무한스크롤 에러를 해결하였습니다.

## 📱 스크린샷


https://user-images.githubusercontent.com/57849386/204096654-4b3d7a6d-29dd-47bf-aa03-98d27cf29206.mp4



## ✅ 테스트방법
- PR리뷰어가 변경사항을 확인할 수 있는 방법을 서술합니다.

## 📣 PR & Issues
- closed #145

## 📬 참고문서, 레퍼런스
https://stackoverflow.com/questions/47220268/firebase-firestore-pagination-with-swift
