### PR TITLE
💄 헤더뷰 안의 이메일을 삭제하고 아이디의 설정을 바꿨습니다. + 헤더뷰 위치 재조정되는 버그를 수정했습니다.

### DIFF
--- a/Flicker/Global/Supports/SceneDelegate.swift
+++ b/Flicker/Global/Supports/SceneDelegate.swift
@@ -17,10 +17,10 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         guard let windowScene = (scene as? UIWindowScene) else { return }
         window = UIWindow(windowScene: windowScene)
 
-//        let AuthController = UINavigationController(rootViewController: LogInViewController())
+        let AuthController = UINavigationController(rootViewController: LogInViewController())
 //
-//        window?.rootViewController = ( Auth.auth().currentUser != nil && UserDefaults.standard.string(forKey: "userEmail") != nil ) ? TabbarViewController() : AuthController
-        window?.rootViewController = UINavigationController(rootViewController: ArtistEditViewController())
+        window?.rootViewController = ( Auth.auth().currentUser != nil && UserDefaults.standard.string(forKey: "userEmail") != nil ) ? TabbarViewController() : AuthController
+//        window?.rootViewController = UINavigationController(rootViewController: ArtistEditViewController())
         
         window?.makeKeyAndVisible()
     }

--- a/Flicker/Screens/Login/LoginViewController.swift
+++ b/Flicker/Screens/Login/LoginViewController.swift
@@ -211,9 +211,8 @@ final class LogInViewController: BaseViewController {
     
     private func goHome() {
         let viewController = TabbarViewController()
-        let navigationController = UINavigationController(rootViewController: viewController)
-        navigationController.modalPresentationStyle = .fullScreen
-        self.present(navigationController, animated: true, completion: nil)
+        viewController.modalPresentationStyle = .fullScreen
+        self.present(viewController, animated: true, completion: nil)
     }
 
     private func goProfile() {

--- a/Flicker/Screens/Profile/ProfileHeaderVIew.swift
+++ b/Flicker/Screens/Profile/ProfileHeaderVIew.swift
@@ -24,11 +24,8 @@ final class ProfileHeaderVIew: UIView {
         $0.clipsToBounds = true
     }
     
-    private lazy var idLabel = UILabel().then {
-        $0.text = "Unknown"
-        $0.font = .preferredFont(forTextStyle: .largeTitle, weight: .bold)
-        $0.textColor = .textMainBlack
-    }
+    private lazy var idLabel = UILabel().makeBasicLabel(labelText: "Error", textColor: .textMainBlack, fontStyle: .title1, fontWeight: .bold)
+    
     
     override init(frame: CGRect) {
         super.init(frame: frame)
@@ -54,7 +51,7 @@ final class ProfileHeaderVIew: UIView {
         }
         idLabel.snp.makeConstraints {
             $0.centerY.equalTo(profileImage.snp.centerY)
-            $0.leading.equalTo(profileImage.snp.trailing).offset(20)
+            $0.leading.equalTo(profileImage.snp.trailing).offset(10)
         }
     }
     func setupHeaderData( name: String, imageURL: String) async {

--- a/Flicker/Screens/Profile/ProfileHeaderVIew.swift
+++ b/Flicker/Screens/Profile/ProfileHeaderVIew.swift
@@ -30,12 +30,6 @@ final class ProfileHeaderVIew: UIView {
         $0.textColor = .textMainBlack
     }
     
-    private lazy var emailLabel = UILabel().then {
-        $0.text = "User Email Error"
-        $0.font = .preferredFont(forTextStyle: .footnote, weight: .regular)
-        $0.textColor = .textSubBlack
-    }
-    
     override init(frame: CGRect) {
         super.init(frame: frame)
         configureUI()
@@ -47,7 +41,7 @@ final class ProfileHeaderVIew: UIView {
     // MARK: - Render
     func configureUI() {
         addSubviews(headerCard)
-        headerCard.addSubviews(profileImage, idLabel, emailLabel)
+        headerCard.addSubviews(profileImage, idLabel)
         headerCard.snp.makeConstraints {
             $0.top.equalToSuperview().inset(20)
             $0.leading.trailing.equalToSuperview().inset(20)
@@ -59,18 +53,13 @@ final class ProfileHeaderVIew: UIView {
             $0.centerY.equalToSuperview()
         }
         idLabel.snp.makeConstraints {
-            $0.top.equalTo(profileImage.snp.top)
+            $0.centerY.equalTo(profileImage.snp.centerY)
             $0.leading.equalTo(profileImage.snp.trailing).offset(20)
         }
-        emailLabel.snp.makeConstraints {
-            $0.top.equalTo(idLabel.snp.bottom).offset(10)
-            $0.leading.equalTo(idLabel)
-        }
     }
-    func setupHeaderData( name: String, email: String, imageURL: String) async {
+    func setupHeaderData( name: String, imageURL: String) async {
         do {
-            self.idLabel.text = name
-            self.emailLabel.text = email
+            self.idLabel.text = "\(name)님"
             self.profileImage.image = try await NetworkManager.shared.fetchOneImage(withURL: imageURL)
         } catch {
             print(error)

--- a/Flicker/Screens/Profile/ProfileViewController.swift
+++ b/Flicker/Screens/Profile/ProfileViewController.swift
@@ -132,7 +132,7 @@ extension ProfileViewController: UITableViewDataSource {
         let section = ProfileSection(rawValue: indexPath.section)
         if indexPath.item == 0 {
             Task {
-                await profileHeader.setupHeaderData(name: defaults.string(forKey: "userName") ?? "", email: defaults.string(forKey: "userEmail") ?? "", imageURL: defaults.string(forKey: "userProfileImageUrl") ?? "")
+                await profileHeader.setupHeaderData(name: defaults.string(forKey: "userName") ?? "", imageURL: defaults.string(forKey: "userProfileImageUrl") ?? "")
             }
         }
         // section에 !가 붙었는데 코드가 바뀌지 않는 이상 강제 언래핑을 해도 무관하다고 생각합니다.


### PR DESCRIPTION
## 🌁 배경
이메일이 길어지면 표시하기 애매하다는 점과 글자수를 제한하여 맞는 방면으로 표기하기 위함입니다.

## 👩‍💻 작업 내용 (Content)
- Email Label을 제거하고 위치를 조절했습니다.
- 최대 8글자가 들어가기에는 현재 LargeTitle이 너무 크기 때문에 Title1로 스타일을 선정했습니다.

## 📱 스크린샷

![IMG_3E85C8FED48D-1](https://user-images.githubusercontent.com/47441965/204254719-a1741aae-d1d8-4627-bd29-d594949ba0ee.jpeg)

## ✅ 테스트방법
- 간단한 수정이라 스크린샷만 보셔도 됩니다.

## 📣 PR & Issues
close #129 
