### PR TITLE
✨ 프로필뷰 알림 설정 버튼 활성화

### DIFF
--- a/Flicker/Screens/Profile/Cell/ProfileEnumeration.swift
+++ b/Flicker/Screens/Profile/Cell/ProfileEnumeration.swift
@@ -30,7 +30,7 @@ enum ProfileSection: Int, CaseIterable {
         
         switch self {
         case .settings:
-            return ["알람", category, "문의하기"]
+            return ["알림설정", category, "문의하기"]
         case .logout:
             return ["로그아웃"]
         case .signOut:

--- a/Flicker/Screens/Profile/ProfileViewController.swift
+++ b/Flicker/Screens/Profile/ProfileViewController.swift
@@ -92,6 +92,14 @@ final class ProfileViewController: EmailViewController {
             UIApplication.shared.unregisterForRemoteNotifications()
         }
     }
+    
+    private func setNotification() {
+        guard let url = URL(string: UIApplication.openSettingsURLString) else { return }
+
+        if UIApplication.shared.canOpenURL(url) {
+            UIApplication.shared.open(url)
+        }
+    }
 
     private func goToArtistRegistration() {
         transition(RegisterWelcomeViewController(), transitionStyle: .push)
@@ -140,16 +148,7 @@ extension ProfileViewController: UITableViewDataSource {
         // section에 !가 붙었는데 코드가 바뀌지 않는 이상 강제 언래핑을 해도 무관하다고 생각합니다.
         cell.cellTextLabel.text = section!.sectionOptions(isArtist: isArtist)[indexPath.row]
         if section == .settings {
-            switch indexPath.row {
-            case 0:
-                let switchView = UISwitch(frame: .zero)
-                switchView.setOn(true, animated: true)
-                switchView.addTarget(self, action: #selector(didToggleSwitch), for: .valueChanged)
-                cell.accessoryView = switchView
-                cell.selectionStyle = .none
-            default:
-                cell.accessoryType = .disclosureIndicator
-            }
+            cell.accessoryType = .disclosureIndicator
         }
         return cell
     }
@@ -176,6 +175,8 @@ extension ProfileViewController: UITableViewDelegate {
 
         if section == .settings {
             switch indexPath.row {
+            case 0:
+                setNotification()
             case 1:
                 isArtist ? print("이 영역에 작가 프로필을 수정 하는 뷰를 만들어 넣어야 합니다.") : goToArtistRegistration()
             case 2:

--- a/Flicker/Screens/Profile/ProfileViewController.swift
+++ b/Flicker/Screens/Profile/ProfileViewController.swift
@@ -86,8 +86,10 @@ final class ProfileViewController: EmailViewController {
 
     @objc func didToggleSwitch(_ sender: UISwitch) {
         print(sender.isOn)
-        if !sender.isOn {
-            makeAlert(title: "알림 비활성화", message: "")
+        if sender.isOn {
+            UIApplication.shared.registerForRemoteNotifications()
+        } else {
+            UIApplication.shared.unregisterForRemoteNotifications()
         }
     }
 


### PR DESCRIPTION
## 🌁 배경
푸시 알람 관련하여, 앱의 알림 설정을 온오프 할 수 있는 기능을 추가하였습니다.

## 👩‍💻 작업 내용 (Content)
토글 버튼으로 있던 "알람 온오프" 항목을 "알림설정"버튼으로 수정하고, 클릭시에 앱 설정화면으로 넘어가게하였습니다.
놀랍게도 앱설정으로 가는 것은 가능한데, 설정화면의 세부화면으로 가는 것은 불가능하다고 합니다. 맨 하단에 참고링크 읽어보세요!

## 📱 스크린샷

<p align="left">
  <img width="200" alt="스크린샷1" src="https://user-images.githubusercontent.com/57849386/204306527-955419d2-004b-4c5f-a17a-4d2ca5331272.png">
  <img width="200" alt="스크린샷2" src="https://user-images.githubusercontent.com/57849386/204306590-8774f328-bb79-4f8e-812e-380c974444ff.png">
</p>


https://user-images.githubusercontent.com/57849386/204306876-ac13f66c-b3d8-4729-98cd-1cdd649eea47.mp4


## ✅ 테스트방법
- PR리뷰어가 변경사항을 확인할 수 있는 방법을 서술합니다.

## 📣 PR & Issues
- closed #153

## 📬 참고문서, 레퍼런스
https://velog.io/@haze5959/iOS-%EC%84%A4%EC%A0%95%EC%95%B1%EC%9D%98-%ED%8A%B9%EC%A0%95-%ED%99%94%EB%A9%B4%EC%9C%BC%EB%A1%9C-%EC%9D%B4%EB%8F%99%ED%95%98%EA%B8%B0
