### PR TITLE
✨ 푸시 알림 클릭시 채팅방 탭으로 이동

### DIFF
--- a/Flicker/Global/Supports/AppDelegate.swift
+++ b/Flicker/Global/Supports/AppDelegate.swift
@@ -52,4 +52,22 @@ class AppDelegate: UIResponder, UIApplicationDelegate, MessagingDelegate, UNUser
         }
     }
 
+    func userNotificationCenter(_ center: UNUserNotificationCenter,
+                                didReceive response: UNNotificationResponse,
+                                withCompletionHandler completionHandler: @escaping () -> Void) {
+        
+        let application = UIApplication.shared
+        
+        //앱이 켜져있는 상태에서 푸쉬 알림을 눌렀을 때
+        if application.applicationState == .active {
+            print("푸쉬알림 탭(앱 켜져있음)")
+            NotificationCenter.default.post(name: Notification.Name("showPage"), object: nil, userInfo: ["index": 2])
+        }
+        
+        //앱이 꺼져있는 상태에서 푸쉬 알림을 눌렀을 때
+        if application.applicationState == .inactive {
+            print("푸쉬알림 탭(앱 꺼져있음)")
+            NotificationCenter.default.post(name: Notification.Name("showPage"), object: nil, userInfo: ["index": 2])
+        }
+    }
 }

--- a/Flicker/Screens/Tabbar/TabbarViewController.swift
+++ b/Flicker/Screens/Tabbar/TabbarViewController.swift
@@ -15,8 +15,6 @@ final class TabbarViewController: UITabBarController {
     private let profileViewController = UINavigationController(rootViewController: ProfileViewController())
     
     override func viewDidLoad() {
-
-
         super.viewDidLoad()
         
         mainViewController.tabBarItem.image = ImageLiteral.btnMain
@@ -31,9 +29,11 @@ final class TabbarViewController: UITabBarController {
         profileViewController.tabBarItem.image = ImageLiteral.btnProfile
         profileViewController.tabBarItem.title = "프로필"
         
-        tabBar.tintColor = .mainYellow
+        tabBar.tintColor = .mainPink
         tabBar.backgroundColor = .white
         setViewControllers([mainViewController, searchViewController, messageViewController, profileViewController], animated: true)
+        
+        NotificationCenter.default.addObserver(self, selector: #selector(showPage(_:)), name: NSNotification.Name("showPage"), object: nil)
     }
 
     override func viewWillAppear(_ animated: Bool) {
@@ -41,4 +41,11 @@ final class TabbarViewController: UITabBarController {
         navigationController?.setNavigationBarHidden(true, animated: false)
     }
 
+    @objc func showPage(_ notification: Notification) {
+        if let userInfo = notification.userInfo {
+            if let index = userInfo["index"] as? Int {
+                self.selectedIndex = index
+            }
+        }
+    }
 }


### PR DESCRIPTION
## 🌁 배경
푸시 알림 클릭시에, 그저 앱이 켜지는 것에 불과하였습니다.
이를, 클릭시에 채팅방 탭으로 앱이 켜지는 것으로 수정하였습니다.

** 제한 사항 **
- 앱의 디비가 불안정하여, 푸시 알림이 잘 이루어지지 않아 테스트를 못했습니다.
- 푸시 알림에 해당하는 채팅방으로 바로 화면이 켜지는 것은, 시간이 꽤 걸릴 것 같아 보류하였습니다.
- 읽지 않은 채팅의 갯수만큼 탭에 "뱃지"로 숫자표시하는 기능은, 디비 구조의 변경 등 관련 작업이 많아 보류하였습니다.

## 👩‍💻 작업 내용 (Content)
- 푸시 알림 클릭시에, 메시지 탭으로 앱이 켜짐

## 📱 스크린샷
- 화면 전환이나 인터렉션이 있는 경우엔 GIF, 정적인 화면이라면 스크린샷을 이용합니다.


## ✅ 테스트방법
- PR리뷰어가 변경사항을 확인할 수 있는 방법을 서술합니다.

## 📣 PR & Issues
- closed #156

## 📬 참고문서, 레퍼런스
https://fomaios.tistory.com/entry/iOS-%ED%91%B8%EC%89%AC-%EC%95%8C%EB%A6%BC-%ED%83%AD%ED%96%88%EC%9D%84-%EB%95%8C-%ED%8A%B9%EC%A0%95-%ED%8E%98%EC%9D%B4%EC%A7%80%EB%A1%9C-%EC%9D%B4%EB%8F%99%ED%95%98%EA%B8%B0
