### PR TITLE
✨ 회원가입시 닉네임의 길이를 8글자로 제한하는 기능을 추가했습니다.

### DIFF
--- a/Flicker/Screens/SignUp/LoginProfileViewController.swift
+++ b/Flicker/Screens/SignUp/LoginProfileViewController.swift
@@ -120,10 +120,6 @@ final class LoginProfileViewController: BaseViewController {
         $0.layer.cornerRadius = 15
     }
 
-    private let navigationDivider = UIView().then {
-        $0.backgroundColor = .loginGray
-    }
-
     private let nickNameDivider = UIView().then {
         $0.backgroundColor = .loginGray
     }
@@ -134,7 +130,7 @@ final class LoginProfileViewController: BaseViewController {
         nickNameTextFieldClearButton.isHidden = true
         nickNameCountLabel.isHidden = true
 
-        view.addSubviews(profileImageView, cameraImage ,profileLabelFirst, profileLabelSecond, nickNameLabel, isArtistLabel, afterJoinLabel, nickNameField, nickNameCountLabel ,artistTrueButton, artistFalseButton, signUpButton, navigationDivider, nickNameTextFieldClearButton, nickNameDivider)
+        view.addSubviews(profileImageView, cameraImage ,profileLabelFirst, profileLabelSecond, nickNameLabel, isArtistLabel, afterJoinLabel, nickNameField, nickNameCountLabel ,artistTrueButton, artistFalseButton, signUpButton, nickNameTextFieldClearButton, nickNameDivider)
 
         view.addSubviews(loadingView, spinnerView,loadingLabel)
 
@@ -143,12 +139,6 @@ final class LoginProfileViewController: BaseViewController {
         artistFalseButton.addTarget(self, action: #selector(didTapArtistFalseButton), for: .touchUpInside)
         signUpButton.addTarget(self, action: #selector(didTapSignUpButton), for: .touchUpInside)
         nickNameTextFieldClearButton.addTarget(self, action: #selector(didTapClearButton), for: .touchUpInside)
-
-        navigationDivider.snp.makeConstraints {
-            $0.top.equalTo(view.safeAreaLayoutGuide.snp.top)
-            $0.leading.trailing.equalToSuperview()
-            $0.height.equalTo(1)
-        }
 
         profileImageView.snp.makeConstraints {
             $0.top.equalTo(view.safeAreaLayoutGuide.snp.top).offset(50)
@@ -241,11 +231,6 @@ final class LoginProfileViewController: BaseViewController {
             $0.centerX.equalToSuperview()
             $0.centerY.equalTo(self.spinnerView.snp.bottom).offset(35)
         }
-    }
-
-    override func setupNavigationBar() {
-        super.setupNavigationBar()
-        title = "프로필 입력"
     }
 
     @objc private func selectButtonTouched(_ recognizer: UITapGestureRecognizer) {

--- a/Flicker/Screens/SignUp/LoginProfileViewController.swift
+++ b/Flicker/Screens/SignUp/LoginProfileViewController.swift
@@ -18,6 +18,7 @@ final class LoginProfileViewController: BaseViewController {
     var authEmail: String = ""
     var authPassword: String = ""
 
+    private var nickNameCount: Int = 0
     private var isNickNameWrite = false
     private var isTapArtistButton = false
 
@@ -74,14 +75,14 @@ final class LoginProfileViewController: BaseViewController {
     private let isArtistLabel = UILabel().makeBasicLabel(labelText: "사진작가로 활동할 예정이신가요?", textColor: .black, fontStyle: .title3, fontWeight: .bold)
     private let afterJoinLabel = UILabel().makeBasicLabel(labelText: "가입 후 마이프로필에서 작가등록을 하실 수 있어요!", textColor: .textSubBlack, fontStyle: .caption1, fontWeight: .medium)
 
-    private let nickNameField = UITextField().then {
+    private lazy var nickNameField = UITextField().then {
         let attributes = [
             NSAttributedString.Key.foregroundColor : UIColor.textSubBlack,
             NSAttributedString.Key.font : UIFont.systemFont(ofSize: 17, weight: .light)
         ]
 
-        $0.backgroundColor = .clear
-        $0.attributedPlaceholder = NSAttributedString(string: "닉네임을 입력해 주세요!", attributes: attributes)
+        $0.backgroundColor = .red
+        $0.attributedPlaceholder = NSAttributedString(string: "닉네임을 입력해 주세요.", attributes: attributes)
         $0.autocapitalizationType = .none
         $0.layer.masksToBounds = true
         $0.leftView = UIView(frame: CGRect(x: 0, y: 0, width: 5, height: 0))
@@ -90,6 +91,8 @@ final class LoginProfileViewController: BaseViewController {
         $0.makeShadow(color: .black, opacity: 0.08, offset: CGSize(width: 0, height: 4), radius: 20)
         $0.autocorrectionType = .no
     }
+
+    private lazy var nickNameCountLabel = UILabel().makeBasicLabel(labelText: "\(self.nickNameCount)/8", textColor: .textMainBlack, fontStyle: .body, fontWeight: .bold)
 
     private let nickNameTextFieldClearButton = UIButton().then {
         $0.setImage(UIImage(systemName: "x.circle"), for: .normal)
@@ -130,7 +133,7 @@ final class LoginProfileViewController: BaseViewController {
         signUpButton.isEnabled = false
         nickNameTextFieldClearButton.isHidden = true
 
-        view.addSubviews(profileImageView, cameraImage ,profileLabelFirst, profileLabelSecond, nickNameLabel, isArtistLabel, afterJoinLabel, nickNameField, artistTrueButton, artistFalseButton, signUpButton, navigationDivider, nickNameTextFieldClearButton, nickNameDivider)
+        view.addSubviews(profileImageView, cameraImage ,profileLabelFirst, profileLabelSecond, nickNameLabel, isArtistLabel, afterJoinLabel, nickNameField, nickNameCountLabel ,artistTrueButton, artistFalseButton, signUpButton, navigationDivider, nickNameTextFieldClearButton, nickNameDivider)
 
         view.addSubviews(loadingView, spinnerView,loadingLabel)
 
@@ -176,12 +179,17 @@ final class LoginProfileViewController: BaseViewController {
         nickNameField.snp.makeConstraints {
             $0.top.equalTo(nickNameLabel.snp.bottom).offset(10)
             $0.leading.equalToSuperview().inset(20)
-            $0.trailing.equalToSuperview().inset(60)
+            $0.trailing.equalToSuperview().inset(100)
+        }
+
+        nickNameCountLabel.snp.makeConstraints {
+            $0.centerY.equalTo(nickNameField.snp.centerY)
+            $0.leading.equalTo(nickNameField.snp.trailing).offset(10)
         }
 
         nickNameTextFieldClearButton.snp.makeConstraints {
             $0.centerY.equalTo(nickNameField.snp.centerY)
-            $0.leading.equalTo(nickNameField.snp.trailing)
+            $0.leading.equalTo(nickNameField.snp.trailing).offset(40)
             $0.trailing.equalToSuperview().inset(30)
         }
 
@@ -333,11 +341,24 @@ final class LoginProfileViewController: BaseViewController {
 
 extension LoginProfileViewController: UIImagePickerControllerDelegate, UINavigationControllerDelegate  {
 
+    func textField(_ textField: UITextField, shouldChangeCharactersIn range: NSRange, replacementString string: String) -> Bool {
+        if let char = string.cString(using: String.Encoding.utf8) {
+            let isBackSpace = strcmp(char, "\\b")
+            if isBackSpace == -92 {
+                return true
+            }
+        }
+        return range.upperBound < 8
+    }
+
     override func textFieldDidBeginEditing(_ textField: UITextField) {
         nickNameTextFieldClearButton.isHidden = false
     }
 
+
     func textFieldDidChangeSelection(_ textField: UITextField) {
+
+        nickNameCountLabel.text = "\(nickNameField.text?.count ?? 0)/8"
 
         isNickNameWrite = nickNameField.text!.isEmpty ? false : true
 

--- a/Flicker/Screens/SignUp/LoginProfileViewController.swift
+++ b/Flicker/Screens/SignUp/LoginProfileViewController.swift
@@ -81,7 +81,7 @@ final class LoginProfileViewController: BaseViewController {
             NSAttributedString.Key.font : UIFont.systemFont(ofSize: 17, weight: .light)
         ]
 
-        $0.backgroundColor = .red
+        $0.backgroundColor = .clear
         $0.attributedPlaceholder = NSAttributedString(string: "닉네임을 입력해 주세요.", attributes: attributes)
         $0.autocapitalizationType = .none
         $0.layer.masksToBounds = true
@@ -92,7 +92,7 @@ final class LoginProfileViewController: BaseViewController {
         $0.autocorrectionType = .no
     }
 
-    private lazy var nickNameCountLabel = UILabel().makeBasicLabel(labelText: "\(self.nickNameCount)/8", textColor: .textMainBlack, fontStyle: .body, fontWeight: .bold)
+    private lazy var nickNameCountLabel = UILabel().makeBasicLabel(labelText: "(\(self.nickNameCount)/8)", textColor: .textMainBlack, fontStyle: .body, fontWeight: .bold)
 
     private let nickNameTextFieldClearButton = UIButton().then {
         $0.setImage(UIImage(systemName: "x.circle"), for: .normal)
@@ -132,6 +132,7 @@ final class LoginProfileViewController: BaseViewController {
         nickNameField.delegate = self
         signUpButton.isEnabled = false
         nickNameTextFieldClearButton.isHidden = true
+        nickNameCountLabel.isHidden = true
 
         view.addSubviews(profileImageView, cameraImage ,profileLabelFirst, profileLabelSecond, nickNameLabel, isArtistLabel, afterJoinLabel, nickNameField, nickNameCountLabel ,artistTrueButton, artistFalseButton, signUpButton, navigationDivider, nickNameTextFieldClearButton, nickNameDivider)
 
@@ -184,7 +185,7 @@ final class LoginProfileViewController: BaseViewController {
 
         nickNameCountLabel.snp.makeConstraints {
             $0.centerY.equalTo(nickNameField.snp.centerY)
-            $0.leading.equalTo(nickNameField.snp.trailing).offset(10)
+            $0.leading.equalTo(nickNameField.snp.trailing)
         }
 
         nickNameTextFieldClearButton.snp.makeConstraints {
@@ -212,7 +213,7 @@ final class LoginProfileViewController: BaseViewController {
         artistTrueButton.snp.makeConstraints {
             $0.top.equalTo(afterJoinLabel.snp.bottom).offset(10)
             $0.leading.equalToSuperview().inset(20)
-            $0.trailing.equalTo(view.snp.centerX).inset(25 )
+            $0.trailing.equalTo(view.snp.centerX).inset(25)
         }
 
         artistFalseButton.snp.makeConstraints {
@@ -318,6 +319,7 @@ final class LoginProfileViewController: BaseViewController {
 
     @objc private func didTapClearButton() {
         self.nickNameField.text = ""
+        self.nickNameCountLabel.isHidden = true
 
         if isTapArtistButton {
             signUpButton.isEnabled = false
@@ -340,7 +342,7 @@ final class LoginProfileViewController: BaseViewController {
 }
 
 extension LoginProfileViewController: UIImagePickerControllerDelegate, UINavigationControllerDelegate  {
-
+    //8글자를 입력하면 백스페이스를 포함한 어떠한 입력도 입력되지 않아 예외처리로 지우기는 가능하게 하는 코드입니다.
     func textField(_ textField: UITextField, shouldChangeCharactersIn range: NSRange, replacementString string: String) -> Bool {
         if let char = string.cString(using: String.Encoding.utf8) {
             let isBackSpace = strcmp(char, "\\b")
@@ -348,7 +350,9 @@ extension LoginProfileViewController: UIImagePickerControllerDelegate, UINavigat
                 return true
             }
         }
-        return range.upperBound < 8
+
+        guard nickNameField.text?.count ?? 0 < 8 else { return false }
+        return true
     }
 
     override func textFieldDidBeginEditing(_ textField: UITextField) {
@@ -358,7 +362,9 @@ extension LoginProfileViewController: UIImagePickerControllerDelegate, UINavigat
 
     func textFieldDidChangeSelection(_ textField: UITextField) {
 
-        nickNameCountLabel.text = "\(nickNameField.text?.count ?? 0)/8"
+        nickNameCountLabel.isHidden = nickNameField.text?.count == 0 ? true : false
+
+        nickNameCountLabel.text = "(\(nickNameField.text?.count ?? 0)/8)"
 
         isNickNameWrite = nickNameField.text!.isEmpty ? false : true
 

--- a/Flicker/Screens/SignUp/SignUpViewController.swift
+++ b/Flicker/Screens/SignUp/SignUpViewController.swift
@@ -94,10 +94,6 @@ final class SignUpViewController: BaseViewController {
         $0.addTarget(self, action: #selector(didTapSignUpButton), for: .touchUpInside)
     }
 
-    private let navigationDivider = UIView().then {
-        $0.backgroundColor = .loginGray
-    }
-
     override func render() {
         emailField.delegate = self
         passwordField.delegate = self
@@ -111,7 +107,7 @@ final class SignUpViewController: BaseViewController {
         passwordValidCheckLabel.isHidden = true
         passwordSameCheckLabel.isHidden = true
 
-        view.addSubviews(emailValidCheckLabel ,signUpTitleLabel, signUpLabel, emailField, passwordField, signUpButton, navigationDivider, passwordSameCheckField, passwordValidCheckLabel, passwordSameCheckLabel)
+        view.addSubviews(emailValidCheckLabel ,signUpTitleLabel, signUpLabel, emailField, passwordField, signUpButton, passwordSameCheckField, passwordValidCheckLabel, passwordSameCheckLabel)
 
         signUpTitleLabel.snp.makeConstraints {
             $0.top.equalTo(view.safeAreaLayoutGuide.snp.top).offset(50)
@@ -163,11 +159,6 @@ final class SignUpViewController: BaseViewController {
             $0.height.equalTo(55)
         }
 
-        navigationDivider.snp.makeConstraints {
-            $0.top.equalTo(view.safeAreaLayoutGuide.snp.top)
-            $0.leading.trailing.equalToSuperview()
-            $0.height.equalTo(1)
-        }
     }
 
     override func viewDidAppear(_ animated: Bool) {


### PR DESCRIPTION
## 🌁 배경
- 프로필 세팅뷰에서 일정 길이 이상으로 닉네임의 String값이 들어가면 UI적으로 문제가 생겨 자체적으로 닉네임의 길이를 8글자로 제한하기로 했습니다.

## 👩‍💻 작업 내용 (Content)
- 닉네임을 적는 텍스트 필드의 길이가 8글자 이상이 될 경우 더 이상 입력을 할 수 없도록 했습니다.
- 추가적으로 모든 입력이 불가해, 지우기 조차 불가하여 백스페이스입력은 가능하도록 코드를 추가했습니다.
- UI적으로 현재 몇글자를 입력했고 몇글자까지 입력할 수 있는지 보여줘 사용자가 알 수 있도록 했습니다.

String은 호출되는 함수의 Parameter로 들어오는 값이며, 사용자가 입력을 시도한 값이 실제 입력이 되는지 여부와 관계없이 계속 들어오게 됩니다. 이때 들어오는 값중 BackSpace값을 판단하고 인코딩하여 UInt32형태로 변환합니다.
BackSpace의 UInt32값은 -92이며,이 조건을 만족하는 경우는 입력을 가능하도록 하여 BackSpace입력은 가능하도록 했습니다.
![스크린샷 2022-11-29 오전 4 51 16](https://user-images.githubusercontent.com/81131715/204368062-3c992e4e-c047-4d6e-9550-16cb9705718d.png)


## 📱 스크린샷
- 화면 전환이나 인터렉션이 있는 경우엔 GIF, 정적인 화면이라면 스크린샷을 이용합니다.

https://user-images.githubusercontent.com/81131715/204367485-bbfaebe4-e251-4f66-a297-bd6796199af6.mp4


## ✅ 테스트방법
회원가입 시 프로필입력 화면에서 닉네임을 입력해보시면 됩니다!

## 📣 PR & Issues
- closed #160 

## 📬 참고문서, 레퍼런스
- https://kasroid.github.io/posts/ios/20200914-uitextfield-limits-number-of-text-detecting-backspace-event/#backspace-event-%EA%B0%90%EC%A7%80%ED%95%98%EA%B8%B0
