### PR TITLE
💄 프로필 세팅 뷰에 있던 프로필 테이블뷰의 헤더가 올라가던 버그를 해결했습니다.

### DIFF
--- a/Flicker/Screens/Login/LoginViewController.swift
+++ b/Flicker/Screens/Login/LoginViewController.swift
@@ -199,10 +199,6 @@ final class LogInViewController: BaseViewController {
         super.setupNavigationBar()
         self.navigationItem.leftBarButtonItem = nil
     }
-    
-    override func viewDidAppear(_ animated: Bool) {
-        super.viewDidAppear(animated)
-    }
 
     override func viewWillDisappear(_ animated: Bool) {
         super.viewWillDisappear(animated)

--- a/Flicker/Screens/Main/MainViewController.swift
+++ b/Flicker/Screens/Main/MainViewController.swift
@@ -78,10 +78,6 @@ final class MainViewController: BaseViewController {
         super.viewDidLoad()
         loadData()
     }
-    override func viewWillAppear(_ animated: Bool) {
-        super.viewWillAppear(animated)
-        navigationController?.setNavigationBarHidden(true, animated: false)
-    }
     
     override func render() {
         view.addSubviews(appTitleLabel, regionTagButton, emptyThumnailView, listCollectionView, emptyThumnailView)

--- a/Flicker/Screens/Profile/ProfileViewController.swift
+++ b/Flicker/Screens/Profile/ProfileViewController.swift
@@ -38,27 +38,22 @@ final class ProfileViewController: EmailViewController {
         navigationController?.setNavigationBarHidden(true, animated: false)
         tabBarController?.tabBar.isHidden = false
     }
-
-    override func viewWillDisappear(_ animated: Bool) {
-        super.viewWillDisappear(animated)
-        navigationController?.setNavigationBarHidden(true, animated: false)
-    }
     
     override func render() {
         view.backgroundColor = .systemGray6
         view.addSubviews(tableView, profileHeader)
         profileHeader.snp.makeConstraints {
             $0.leading.trailing.equalToSuperview()
-            $0.top.equalTo(tableView.snp.top)
+            $0.top.equalTo(view.safeAreaLayoutGuide.snp.top)
             $0.height.equalTo(180)
         }
 
         tableView.snp.makeConstraints {
             $0.leading.trailing.equalToSuperview()
-            $0.top.bottom.equalTo(view.safeAreaLayoutGuide)
+            $0.top.equalTo(profileHeader.snp.bottom)
+            $0.bottom.equalTo(view.safeAreaLayoutGuide)
         }
 
-        tableView.tableHeaderView = profileHeader
     }
 
     private func setFunctionsAndDelegate() {

--- a/Flicker/Screens/Tabbar/TabbarViewController.swift
+++ b/Flicker/Screens/Tabbar/TabbarViewController.swift
@@ -34,10 +34,4 @@ final class TabbarViewController: UITabBarController {
         tabBar.backgroundColor = .white
         setViewControllers([mainViewController, searchViewController, messageViewController, profileViewController], animated: true)
     }
-
-//    override func viewWillAppear(_ animated: Bool) {
-//        super.viewWillAppear(animated)
-//        navigationController?.setNavigationBarHidden(true, animated: false)
-//    }
-
 }

--- a/Flicker/Screens/Tabbar/TabbarViewController.swift
+++ b/Flicker/Screens/Tabbar/TabbarViewController.swift
@@ -35,9 +35,9 @@ final class TabbarViewController: UITabBarController {
         setViewControllers([mainViewController, searchViewController, messageViewController, profileViewController], animated: true)
     }
 
-    override func viewWillAppear(_ animated: Bool) {
-        super.viewWillAppear(animated)
-        navigationController?.setNavigationBarHidden(true, animated: false)
-    }
+//    override func viewWillAppear(_ animated: Bool) {
+//        super.viewWillAppear(animated)
+//        navigationController?.setNavigationBarHidden(true, animated: false)
+//    }
 
 }


### PR DESCRIPTION
## 🌁 배경
- 네비게이션바 문제로 생각되었던 프로필세팅 뷰의 헤더가 올라가던 부분이 네비게이션 바 문제가 아닌 테이블 뷰내에서 테이블 뷰 헤더를 한번 더 선언하여 헤더의 크기만큼 테이블 뷰의 공간이 헤더위치에 생겨 올라가던 것이였습니다.

## 👩‍💻 작업 내용 (Content)
- 테이블 뷰 헤더의 오토레이아웃을 뷰자체에 맞추고 테이블뷰도 따로 맞췄습니다.

## 📱 스크린샷
- 화면 전환이나 인터렉션이 있는 경우엔 GIF, 정적인 화면이라면 스크린샷을 이용합니다.

https://user-images.githubusercontent.com/81131715/204422130-06c3c18a-7d0e-4323-9633-acd3496b80a5.mp4



## ✅ 테스트방법
- 화면을 왓다리갔다리 해보시면 됩니다.

## 📣 PR & Issues
- closed #162 