### PR TITLE
🐛 ProfileSetting에서 이동이 가능하게 만들었고 버튼을 눌렀을때 돌아가는 곳을 Profile로 수정했습니다.

### DIFF
--- a/Flicker.xcodeproj/project.pbxproj
+++ b/Flicker.xcodeproj/project.pbxproj
@@ -989,9 +989,11 @@
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_ENTITLEMENTS = Flicker/Flicker.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
-				CODE_SIGN_STYLE = Automatic;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				CODE_SIGN_STYLE = Manual;
 				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_TEAM = 3Y8YH8GWMM;
+				DEVELOPMENT_TEAM = "";
+				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = 3Y8YH8GWMM;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = Flicker/Global/Supports/Info.plist;
 				INFOPLIST_KEY_NSCameraUsageDescription = "";
@@ -1011,6 +1013,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.dime.Flicker;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
+				"PROVISIONING_PROFILE_SPECIFIER[sdk=iphoneos*]" = FlickerProvisioning;
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
 				SUPPORTS_MACCATALYST = NO;
 				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = NO;
@@ -1027,9 +1030,11 @@
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_ENTITLEMENTS = Flicker/Flicker.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
-				CODE_SIGN_STYLE = Automatic;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				CODE_SIGN_STYLE = Manual;
 				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_TEAM = 3Y8YH8GWMM;
+				DEVELOPMENT_TEAM = "";
+				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = 3Y8YH8GWMM;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = Flicker/Global/Supports/Info.plist;
 				INFOPLIST_KEY_NSCameraUsageDescription = "";
@@ -1049,6 +1054,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.dime.Flicker;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
+				"PROVISIONING_PROFILE_SPECIFIER[sdk=iphoneos*]" = FlickerProvisioning;
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
 				SUPPORTS_MACCATALYST = NO;
 				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = NO;

--- a/Flicker/Screens/Profile/ProfileViewController.swift
+++ b/Flicker/Screens/Profile/ProfileViewController.swift
@@ -37,6 +37,7 @@ final class ProfileViewController: EmailViewController {
         super.viewWillAppear(animated)
         navigationController?.setNavigationBarHidden(true, animated: false)
         tabBarController?.tabBar.isHidden = false
+        tableView.reloadData()
     }
 
     override func viewWillDisappear(_ animated: Bool) {

--- a/Flicker/Screens/ProfileSetting/ProfileSettingViewController.swift
+++ b/Flicker/Screens/ProfileSetting/ProfileSettingViewController.swift
@@ -13,7 +13,6 @@ import Firebase
 
 final class ProfileSettingViewController: BaseViewController {
     private var isNickNameWrite = false
-//    private var isImageWrite = false
     private let defaults = UserDefaults.standard
     var currentUserName: String = ""
     private lazy var imagePicker = UIImagePickerController().then {

--- a/Flicker/Screens/ProfileSetting/ProfileSettingViewController.swift
+++ b/Flicker/Screens/ProfileSetting/ProfileSettingViewController.swift
@@ -184,16 +184,31 @@ final class ProfileSettingViewController: BaseViewController {
     
     @objc private func didTapClearButton() {
         self.nickNameField.text = ""
+        self.signUpButton.isEnabled = false
+        self.signUpButton.backgroundColor = .loginGray
     }
 }
 
 extension ProfileSettingViewController : UIImagePickerControllerDelegate, UINavigationControllerDelegate  {
     
+    override func textFieldDidBeginEditing(_ textField: UITextField) {
+        if nickNameField.text!.isEmpty {
+            nickNameTextFieldClearButton.isHidden = true
+            disableButton()
+        }
+    }
+    func textFieldDidChangeSelection(_ textField: UITextField) {
+        if nickNameField.text!.isEmpty {
+            nickNameTextFieldClearButton.isHidden = true
+            disableButton()
+        }
+    }
     override func textFieldDidEndEditing(_ textField: UITextField) {
-        isNickNameWrite = true
-        nickNameTextFieldClearButton.isHidden = false
-        signUpButton.isEnabled = true
-        signUpButton.backgroundColor = .mainPink
+        if !nickNameField.text!.isEmpty {
+            nickNameTextFieldClearButton.isHidden = false
+            signUpButton.isEnabled = true
+            signUpButton.backgroundColor = .mainPink
+        }
     }
     
     func imagePickerController(_ picker: UIImagePickerController, didFinishPickingMediaWithInfo info: [UIImagePickerController.InfoKey : Any]) {
@@ -207,5 +222,9 @@ extension ProfileSettingViewController : UIImagePickerControllerDelegate, UINavi
         }
         self.profileImageView.image = newImage
         dismiss(animated: true, completion: nil)
+    }
+    func disableButton() {
+        signUpButton.isEnabled = false
+        signUpButton.backgroundColor = .loginGray
     }
 }

--- a/Flicker/Screens/ProfileSetting/ProfileSettingViewController.swift
+++ b/Flicker/Screens/ProfileSetting/ProfileSettingViewController.swift
@@ -175,9 +175,10 @@ final class ProfileSettingViewController: BaseViewController {
                                                               name: nickNameField.text ?? "",
                                                               profileImage: profileImageView.image ?? UIImage(systemName: "person")! )
             await CurrentUserDataManager.shared.saveUserDefault()
-            self?.navigationController?.pushViewController(viewController, animated: true)
+            self?.navigationController?.popViewController(animated: true)
+            
         }
-        self.dismiss(animated: true, completion: nil)
+      
     }
     
     @objc private func didTapClearButton() {

--- a/Flicker/Screens/ProfileSetting/ProfileSettingViewController.swift
+++ b/Flicker/Screens/ProfileSetting/ProfileSettingViewController.swift
@@ -10,12 +10,10 @@ import SnapKit
 import Then
 import FirebaseAuth
 import Firebase
-/*
- LoginProfileViewController와 같은 뷰이지만 재사용성을 강조해 두 뷰를 종속시키는 것 보다
- 그냥 같은 뷰를 새로 그려 따로 관리하는 것이 더 효율적이라고 생각이 되어 거의 같은 코드를 쓰는 뷰가 두 개가 있습니다.
- */
+
 final class ProfileSettingViewController: BaseViewController {
     private var isNickNameWrite = false
+//    private var isImageWrite = false
     private let defaults = UserDefaults.standard
     var currentUserName: String = ""
     private lazy var imagePicker = UIImagePickerController().then {
@@ -221,6 +219,12 @@ extension ProfileSettingViewController : UIImagePickerControllerDelegate, UINavi
             newImage = possibleImage        // 원본 이미지가 있을 경우
         }
         self.profileImageView.image = newImage
+        if nickNameField.text!.isEmpty {
+            nickNameTextFieldClearButton.isHidden = false
+            nickNameField.text = currentUserName
+            signUpButton.isEnabled = true
+            signUpButton.backgroundColor = .mainPink
+        }
         dismiss(animated: true, completion: nil)
     }
     func disableButton() {

--- a/Flicker/Screens/Tabbar/TabbarViewController.swift
+++ b/Flicker/Screens/Tabbar/TabbarViewController.swift
@@ -4,7 +4,6 @@
 //
 //  Created by COBY_PRO on 2022/10/24.
 //
-//TODO: navigationBackButton 지워야합니다앗 
 import UIKit
 
 final class TabbarViewController: UITabBarController {
@@ -15,8 +14,6 @@ final class TabbarViewController: UITabBarController {
     private let profileViewController = UINavigationController(rootViewController: ProfileViewController())
     
     override func viewDidLoad() {
-
-
         super.viewDidLoad()
         
         mainViewController.tabBarItem.image = ImageLiteral.btnMain
@@ -40,5 +37,4 @@ final class TabbarViewController: UITabBarController {
         super.viewWillAppear(animated)
         navigationController?.setNavigationBarHidden(true, animated: false)
     }
-
 }


### PR DESCRIPTION
## 🌁 배경
- 프로필 수정과 연관되어 버그가 존재했습니다. 

## 👩‍💻 작업 내용 (Content)
- 이미지를 변경할시 기존 닉네임을 그대로 살려서 수정 가능하게 했습니다. 사용자가 자신의 정보를 변경하고자 할경우 정상 반영됩니다.
- 빈문자열이 안 들어가게 조치했습니다.
- 수정완료 버튼을 누르면 바로 이전뷰로 돌아가게 조치했습니다.

## 📱 스크린샷

![Simulator Screen Recording - iPhone 14 Pro - 2022-11-29 at 11 21 38](https://user-images.githubusercontent.com/47441965/204423412-55c2f12d-c402-4beb-adea-98d4286ae833.gif)


## ✅ 테스트방법
- ProfileView와 ProfileSettingView 쪽을 보시면 되겠습니다!

## 📣 PR & Issues
close #157 
