### PR TITLE
🎨 메인화면 작가 썸네일 셀 비율 수정

### DIFF
--- a/Flicker/Screens/Main/Cell/ArtistThumnailCollectionViewCell.swift
+++ b/Flicker/Screens/Main/Cell/ArtistThumnailCollectionViewCell.swift
@@ -67,8 +67,8 @@ final class ArtistThumnailCollectionViewCell: BaseCollectionViewCell {
         self.artistThumnailImageView.layer.sublayers?.forEach { $0.removeFromSuperlayer() }
         
         let width: CGFloat = UIScreen.main.bounds.size.width - 40
-        let height: CGFloat = 300.0
-        let sHeight: CGFloat = 150.0
+        let height: CGFloat = width * 0.85
+        let sHeight: CGFloat = height / 2
         let shadow = UIColor.black.withAlphaComponent(0.8).cgColor
 
         let bottomImageGradient = CAGradientLayer()

--- a/Flicker/Screens/Main/MainViewController.swift
+++ b/Flicker/Screens/Main/MainViewController.swift
@@ -18,7 +18,7 @@ final class MainViewController: BaseViewController {
         static let collectionHorizontalSpacing: CGFloat = 20.0
         static let collectionVerticalSpacing: CGFloat = 20.0
         static let cellWidth: CGFloat = UIScreen.main.bounds.size.width - collectionHorizontalSpacing * 2
-        static let cellHeight: CGFloat = 300
+        static let cellHeight: CGFloat = cellWidth * 0.85
         static let collectionInset = UIEdgeInsets(top: 0,
                                                   left: collectionHorizontalSpacing,
                                                   bottom: collectionVerticalSpacing,


### PR DESCRIPTION
## 🌁 배경
디바이스에 따라, 작가 썸네일 셀의 비율이 다르게 보이는 에러를 수정했습니다.

## 👩‍💻 작업 내용 (Content)
- 300으로 고정이었던 셀의 높이를, 피그마를 참고하여, 너비의 0.85의 배율로 수정했습니다.

## 📱 스크린샷
### 기존 화면 비교
<p align="left">
  <img width="200" alt="스크린샷1" src="https://user-images.githubusercontent.com/57849386/204424143-9f79e1c0-aa09-4887-a542-55c55a7d2622.png">
  <img width="200" alt="스크린샷2" src="https://user-images.githubusercontent.com/57849386/204424154-3add0bcc-f7ec-4894-925e-f96d28cf789e.png">
</p>

### 비율 수정 후, 화면 비교
<p align="left">
  <img width="200" alt="스크린샷1" src="https://user-images.githubusercontent.com/57849386/204441914-d78c047e-d6e2-4fd1-b90e-4d785f4fd79f.png">
  <img width="200" alt="스크린샷2" src="https://user-images.githubusercontent.com/57849386/204441919-770d20b1-e462-4894-ace7-891f4df93cd4.png">
</p>


## ✅ 테스트방법
- PR리뷰어가 변경사항을 확인할 수 있는 방법을 서술합니다.

## 📣 PR & Issues
- closed #167

## 📬 참고문서, 레퍼런스
- 작업을 하면서 참고한 문서 및 레퍼런스를 작성합니다.

