### PR TITLE
:bug: ArtistTappedView의 네비게이션바 관련 버그 수정

### DIFF
--- a/Flicker/Screens/Main/MainViewController.swift
+++ b/Flicker/Screens/Main/MainViewController.swift
@@ -228,6 +228,7 @@ extension MainViewController: UICollectionViewDataSource, UICollectionViewDelega
         let vc = ArtistTappedViewController()
         vc.artist = artist
         navigationController?.pushViewController(vc, animated: true)
+        navigationController?.setNavigationBarHidden(false, animated: true)
     }
 }
 


### PR DESCRIPTION
## 🌁 배경
작가디테일뷰를 들어가면 네비게이션바가 없어지는 현상이 발생했습니다.

## 👩‍💻 작업 내용 (Content)
## 이유
메인뷰에서 작가셀을 탭하여 네비게이션될때, 숨겼던 네비게이션바를 다시 숨김해제하는 코드가 없습니다. 메인뷰컨의 버그를 수정하는 과정에서 삭제된 것으로 예상되네요

## 해결
setNavigationBarHidden(fasle) 코드를 추가해서 해결했습니다.

## 📱 스크린샷
- 화면 전환이나 인터렉션이 있는 경우엔 GIF, 정적인 화면이라면 스크린샷을 이용합니다.

<p align="left">
  <img width="200" alt="스크린샷1" src="https://user-images.githubusercontent.com/103009135/204441920-73d2a4bb-0c08-4746-9c78-cb426bb8bf40.png">
  <img width="200" alt="스크린샷2" src="https://user-images.githubusercontent.com/103009135/204441944-aba685d5-59e8-4332-a432-e73a69539fbc.png">
</p>


## 📣 PR & Issues
#168 
