### PR TITLE
💄 기기의 너비,높이 값 Static으로 추가 & 기기별 대응하도록 UI수정

### DIFF
--- a/Flicker.xcodeproj/project.pbxproj
+++ b/Flicker.xcodeproj/project.pbxproj
@@ -13,6 +13,7 @@
 		103EB1FC29224F2600E11A2A /* WithDrawViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 103EB1FB29224F2600E11A2A /* WithDrawViewController.swift */; };
 		107841FF29267C34004849FC /* PopUpViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 107841FE29267C34004849FC /* PopUpViewController.swift */; };
 		108561112923EAB00083E156 /* ProfileSettingViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 108561102923EAB00083E156 /* ProfileSettingViewController.swift */; };
+		10CAB7B32935CD8F00442A49 /* Static.swift in Sources */ = {isa = PBXBuildFile; fileRef = 10CAB7B22935CD8F00442A49 /* Static.swift */; };
 		10FE6B6029064FE60064201F /* FirebaseAuth in Frameworks */ = {isa = PBXBuildFile; productRef = 10FE6B5F29064FE60064201F /* FirebaseAuth */; };
 		10FE6B6229064FE60064201F /* FirebaseFirestore in Frameworks */ = {isa = PBXBuildFile; productRef = 10FE6B6129064FE60064201F /* FirebaseFirestore */; };
 		10FE6B6429064FE60064201F /* FirebaseFirestoreSwift in Frameworks */ = {isa = PBXBuildFile; productRef = 10FE6B6329064FE60064201F /* FirebaseFirestoreSwift */; };
@@ -115,6 +116,7 @@
 		103EB1FB29224F2600E11A2A /* WithDrawViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WithDrawViewController.swift; sourceTree = "<group>"; };
 		107841FE29267C34004849FC /* PopUpViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PopUpViewController.swift; sourceTree = "<group>"; };
 		108561102923EAB00083E156 /* ProfileSettingViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfileSettingViewController.swift; sourceTree = "<group>"; };
+		10CAB7B22935CD8F00442A49 /* Static.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Static.swift; sourceTree = "<group>"; };
 		58118D38291132FB00F08D35 /* ArtistRegisterViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ArtistRegisterViewController.swift; sourceTree = "<group>"; };
 		58118D4C29116B5400F08D35 /* RegisterRegionTagCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RegisterRegionTagCell.swift; sourceTree = "<group>"; };
 		58118D4E29116B8B00F08D35 /* LeftAlignedCollectionViewFlowLayout.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LeftAlignedCollectionViewFlowLayout.swift; sourceTree = "<group>"; };
@@ -515,6 +517,7 @@
 				CBDC03FC29060F7A00C6CF30 /* PushNotificationSender.swift */,
 				102A4BEA29253AB2005A8BE5 /* LoginManager.swift */,
 				7B589121292B6568008A950E /* EmailViewController.swift */,
+				10CAB7B22935CD8F00442A49 /* Static.swift */,
 			);
 			path = Utils;
 			sourceTree = "<group>";
@@ -824,6 +827,7 @@
 				58A20CE9292C8C840036A474 /* ArtistEditRegionsViewController.swift in Sources */,
 				58118D4D29116B5400F08D35 /* RegisterRegionTagCell.swift in Sources */,
 				CBDC03D429060E6600C6CF30 /* AppDelegate.swift in Sources */,
+				10CAB7B32935CD8F00442A49 /* Static.swift in Sources */,
 				CBDC04052906100D00C6CF30 /* UICollectionView+Extension.swift in Sources */,
 				58A452A92912A24600C9707D /* RegisterTextDescriptionViewController.swift in Sources */,
 				CB5BF4782919E10700A3E112 /* ChatSendView.swift in Sources */,

--- a/Flicker/Global/Utils/Static.swift
+++ b/Flicker/Global/Utils/Static.swift
@@ -1,0 +1,16 @@
+//
+//  Static.swift
+//  Flicker
+//
+//  Created by 김연호 on 2022/11/29.
+//
+
+import UIKit
+
+final class DeviceFrame {
+    static let screenWidth = UIScreen.main.bounds.size.width
+    static let screenHeight = UIScreen.main.bounds.size.height
+    static var exceptPaddingWidth: CGFloat {
+        return screenWidth - 40
+    }
+}

--- a/Flicker/Screens/Login/LoginViewController.swift
+++ b/Flicker/Screens/Login/LoginViewController.swift
@@ -27,7 +27,7 @@ final class LogInViewController: BaseViewController {
     }
 
     private let loginTitleLabel = UILabel().then {
-        $0.font = UIFont(name: "TsukimiRounded-Bold", size: 30)
+        $0.font = UIFont(name: "TsukimiRounded-Bold", size: 36)
         $0.textColor = .mainPink
         $0.textAlignment = .center
         $0.text = "SHUGGLE"
@@ -56,7 +56,7 @@ final class LogInViewController: BaseViewController {
         $0.backgroundColor = .loginGray
         $0.attributedPlaceholder = NSAttributedString(string: "이메일 주소", attributes: attributes)
         $0.autocapitalizationType = .none
-        $0.layer.cornerRadius = 12
+        $0.layer.cornerRadius = (DeviceFrame.screenHeight * 0.07) / 5
         $0.layer.masksToBounds = true
         $0.leftView = UIView(frame: CGRect(x: 0, y: 0, width: 20, height: 0))
         $0.leftViewMode = .always
@@ -72,7 +72,7 @@ final class LogInViewController: BaseViewController {
         $0.autocorrectionType = .no
         $0.backgroundColor = .loginGray
         $0.attributedPlaceholder = NSAttributedString(string: "비밀번호", attributes: attributes)
-        $0.layer.cornerRadius = 12
+        $0.layer.cornerRadius = (DeviceFrame.screenHeight * 0.07) / 5
         $0.layer.masksToBounds = true
         $0.leftView = UIView(frame: CGRect(x: 0, y: 0, width: 20, height: 0))
         $0.leftViewMode = .always
@@ -82,7 +82,7 @@ final class LogInViewController: BaseViewController {
     }
 
     private let logInbutton = UIButton().then {
-        $0.layer.cornerRadius = 15
+        $0.layer.cornerRadius = (DeviceFrame.screenHeight * 0.07) / 4
         $0.backgroundColor = .mainPink
         $0.setTitleColor(.white, for: .normal)
         $0.setTitle("로그인", for: .normal)
@@ -141,31 +141,31 @@ final class LogInViewController: BaseViewController {
         emailField.snp.makeConstraints {
             $0.top.equalTo(loginNormalLabel.snp.bottom).offset(50)
             $0.leading.trailing.equalToSuperview().inset(20)
-            $0.height.equalTo(60)
+            $0.height.equalTo(DeviceFrame.screenHeight * 0.07)
         }
 
         passwordField.snp.makeConstraints {
             $0.top.equalTo(emailField.snp.bottom).offset(10)
             $0.leading.trailing.equalToSuperview().inset(20)
-            $0.height.equalTo(60)
+            $0.height.equalTo(DeviceFrame.screenHeight * 0.07)
         }
 
         logInbutton.snp.makeConstraints {
             $0.top.equalTo(passwordField.snp.bottom).offset(10)
             $0.leading.trailing.equalToSuperview().inset(20)
-            $0.height.equalTo(60)
+            $0.height.equalTo(DeviceFrame.screenHeight * 0.07)
         }
 
         signUpButton.snp.makeConstraints {
             $0.top.equalTo(logInbutton.snp.bottom).offset(20)
             $0.trailing.equalTo(view.snp.centerX).offset(-40)
-            $0.height.equalTo(30)
+            $0.height.equalTo(DeviceFrame.screenHeight * 0.035)
         }
 
         resetPasswordButton.snp.makeConstraints {
             $0.top.equalTo(logInbutton.snp.bottom).offset(20)
             $0.leading.equalTo(view.snp.centerX).offset(20)
-            $0.height.equalTo(30)
+            $0.height.equalTo(DeviceFrame.screenHeight * 0.035)
         }
 
         loginDividerText.snp.makeConstraints {
@@ -191,7 +191,7 @@ final class LogInViewController: BaseViewController {
             $0.top.equalTo(loginDividerText.snp.bottom).offset(30)
             $0.centerX.equalToSuperview()
             $0.leading.trailing.equalToSuperview().inset(20)
-            $0.height.equalTo(60)
+            $0.height.equalTo(DeviceFrame.screenHeight * 0.07)
         }
     }
     

--- a/Flicker/Screens/Login/ResetPassword/PopUpViewController.swift
+++ b/Flicker/Screens/Login/ResetPassword/PopUpViewController.swift
@@ -16,7 +16,7 @@ final class PopUpViewController: BaseViewController  {
     private let popUpView = UIView().then {
         $0.clipsToBounds = true
         $0.backgroundColor = .white
-        $0.layer.cornerRadius = 12
+        $0.layer.cornerRadius = DeviceFrame.screenHeight * 0.018
     }
 
     private let mainLabel = UILabel().makeBasicLabel(labelText: "이메일을 입력하세요", textColor: .textMainBlack, fontStyle: .headline, fontWeight: .bold)
@@ -32,7 +32,7 @@ final class PopUpViewController: BaseViewController  {
         $0.backgroundColor = .loginGray
         $0.attributedPlaceholder = NSAttributedString(string: "이메일 주소", attributes: attributes)
         $0.autocapitalizationType = .none
-        $0.layer.cornerRadius = 12
+        $0.layer.cornerRadius = DeviceFrame.screenHeight * 0.014
         $0.layer.masksToBounds = true
         $0.leftView = UIView(frame: CGRect(x: 0, y: 0, width: 10, height: 0))
         $0.leftViewMode = .always
@@ -47,7 +47,7 @@ final class PopUpViewController: BaseViewController  {
         $0.backgroundColor = .systemGray
         $0.setTitleColor(.white, for: .normal)
         $0.setTitle("보내기", for: .normal)
-        $0.layer.cornerRadius = 12
+        $0.layer.cornerRadius = DeviceFrame.screenHeight * 0.018
     }
 
     private let cancleButton = UIButton().then {
@@ -55,7 +55,7 @@ final class PopUpViewController: BaseViewController  {
         $0.backgroundColor = .systemGray2
         $0.setTitleColor(.white, for: .normal)
         $0.setTitle("나가기", for: .normal)
-        $0.layer.cornerRadius = 12
+        $0.layer.cornerRadius = DeviceFrame.screenHeight * 0.018
     }
 
 
@@ -72,26 +72,26 @@ final class PopUpViewController: BaseViewController  {
 
         popUpView.snp.makeConstraints {
             $0.center.equalToSuperview()
-            $0.width.equalTo(UIScreen.main.bounds.width * 0.75)
-            $0.height.equalTo(UIScreen.main.bounds.height * 0.35)
+            $0.width.equalTo(DeviceFrame.screenWidth * 0.75)
+            $0.height.equalTo(DeviceFrame.screenHeight * 0.37)
         }
 
         mainLabel.snp.makeConstraints {
-            $0.top.equalTo(popUpView.snp.top).offset(45)
+            $0.top.equalTo(popUpView.snp.top).offset(DeviceFrame.screenHeight * 0.053)
             $0.leading.trailing.equalToSuperview().inset(30)
-            $0.height.equalTo(40)
+            $0.height.equalTo(DeviceFrame.screenHeight * 0.047)
         }
 
         subLabel.snp.makeConstraints {
             $0.top.equalTo(mainLabel.snp.bottom)
             $0.leading.trailing.equalToSuperview().inset(30)
-            $0.height.equalTo(30)
+            $0.height.equalTo(DeviceFrame.screenHeight * 0.035)
         }
 
         emailField.snp.makeConstraints {
             $0.top.equalTo(subLabel.snp.bottom).offset(20)
             $0.leading.trailing.equalToSuperview().inset(30)
-            $0.height.equalTo(60)
+            $0.height.equalTo(DeviceFrame.screenHeight * 0.07)
         }
 
         emailValidCheckLabel.snp.makeConstraints {
@@ -100,15 +100,15 @@ final class PopUpViewController: BaseViewController  {
         }
         
         sendEmailButton.snp.makeConstraints {
-            $0.top.equalTo(emailField.snp.bottom).offset(35)
-            $0.height.equalTo(50)
+            $0.top.equalTo(emailField.snp.bottom).offset(DeviceFrame.screenHeight * 0.042)
+            $0.height.equalTo(DeviceFrame.screenHeight * 0.05)
             $0.leading.equalToSuperview().inset(30)
             $0.trailing.equalTo(emailField.snp.centerX).offset(-5)
         }
 
         cancleButton.snp.makeConstraints {
-            $0.top.equalTo(emailField.snp.bottom).offset(35)
-            $0.height.equalTo(50)
+            $0.top.equalTo(emailField.snp.bottom).offset(DeviceFrame.screenHeight * 0.042)
+            $0.height.equalTo(DeviceFrame.screenHeight * 0.05)
             $0.leading.equalTo(emailField.snp.centerX).offset(5)
             $0.trailing.equalToSuperview().inset(30)
 

--- a/Flicker/Screens/Login/ResetPassword/PopUpViewController.swift
+++ b/Flicker/Screens/Login/ResetPassword/PopUpViewController.swift
@@ -19,9 +19,9 @@ final class PopUpViewController: BaseViewController  {
         $0.layer.cornerRadius = DeviceFrame.screenHeight * 0.018
     }
 
-    private let mainLabel = UILabel().makeBasicLabel(labelText: "이메일을 입력하세요", textColor: .textMainBlack, fontStyle: .headline, fontWeight: .bold)
+    private let mainLabel = UILabel().makeBasicLabel(labelText: "이메일을 입력하세요", textColor: .mainPink, fontStyle: .title3, fontWeight: .bold)
 
-    private let subLabel = UILabel().makeBasicLabel(labelText: "이메일을 통해 비밀번호 재설정을 할 수 있어요!", textColor: .textMainBlack, fontStyle: .caption1, fontWeight: .bold)
+    private let subLabel = UILabel().makeBasicLabel(labelText: "이메일로 비밀번호 재설정을 해요!", textColor: .textMainBlack, fontStyle: .caption2, fontWeight: .bold)
 
     private let emailField = UITextField().then {
         let attributes = [
@@ -72,7 +72,7 @@ final class PopUpViewController: BaseViewController  {
 
         popUpView.snp.makeConstraints {
             $0.center.equalToSuperview()
-            $0.width.equalTo(DeviceFrame.screenWidth * 0.75)
+            $0.width.equalTo(DeviceFrame.screenWidth * 0.85)
             $0.height.equalTo(DeviceFrame.screenHeight * 0.37)
         }
 
@@ -84,7 +84,7 @@ final class PopUpViewController: BaseViewController  {
 
         subLabel.snp.makeConstraints {
             $0.top.equalTo(mainLabel.snp.bottom)
-            $0.leading.trailing.equalToSuperview().inset(30)
+            $0.leading.trailing.equalToSuperview().inset(31)
             $0.height.equalTo(DeviceFrame.screenHeight * 0.035)
         }
 

--- a/Flicker/Screens/Login/ResetPassword/PopUpViewController.swift
+++ b/Flicker/Screens/Login/ResetPassword/PopUpViewController.swift
@@ -84,14 +84,14 @@ final class PopUpViewController: BaseViewController  {
 
         subLabel.snp.makeConstraints {
             $0.top.equalTo(mainLabel.snp.bottom)
-            $0.leading.trailing.equalToSuperview().inset(31)
+            $0.leading.trailing.equalToSuperview().inset(32)
             $0.height.equalTo(DeviceFrame.screenHeight * 0.035)
         }
 
         emailField.snp.makeConstraints {
-            $0.top.equalTo(subLabel.snp.bottom).offset(20)
+            $0.top.equalTo(subLabel.snp.bottom).offset(10)
             $0.leading.trailing.equalToSuperview().inset(30)
-            $0.height.equalTo(DeviceFrame.screenHeight * 0.07)
+            $0.height.equalTo(DeviceFrame.screenHeight * 0.065)
         }
 
         emailValidCheckLabel.snp.makeConstraints {

--- a/Flicker/Screens/Profile/ProfileHeaderVIew.swift
+++ b/Flicker/Screens/Profile/ProfileHeaderVIew.swift
@@ -20,7 +20,7 @@ final class ProfileHeaderVIew: UIView {
     private lazy var profileImage = UIImageView().then {
         $0.image = UIImage(named: "DefaultProfile")
         $0.contentMode = .scaleToFill
-        $0.layer.cornerRadius = 40
+        $0.layer.cornerRadius = (DeviceFrame.screenHeight * 0.086) / 2
         $0.clipsToBounds = true
     }
     
@@ -45,13 +45,13 @@ final class ProfileHeaderVIew: UIView {
             $0.bottom.equalToSuperview()
         }
         profileImage.snp.makeConstraints {
-            $0.height.width.equalTo(80)
+            $0.height.width.equalTo(DeviceFrame.screenHeight * 0.086)
             $0.leading.equalTo(headerCard.snp.leading).inset(30)
             $0.centerY.equalToSuperview()
         }
         idLabel.snp.makeConstraints {
             $0.centerY.equalTo(profileImage.snp.centerY)
-            $0.leading.equalTo(profileImage.snp.trailing).offset(10)
+            $0.leading.equalTo(profileImage.snp.trailing).offset(20)
         }
     }
     func setupHeaderData( name: String, imageURL: String) async {

--- a/Flicker/Screens/Profile/ProfileViewController.swift
+++ b/Flicker/Screens/Profile/ProfileViewController.swift
@@ -45,7 +45,7 @@ final class ProfileViewController: EmailViewController {
         profileHeader.snp.makeConstraints {
             $0.leading.trailing.equalToSuperview()
             $0.top.equalTo(view.safeAreaLayoutGuide.snp.top)
-            $0.height.equalTo(180)
+            $0.height.equalTo(DeviceFrame.screenHeight * 0.2)
         }
 
         tableView.snp.makeConstraints {

--- a/Flicker/Screens/SignUp/LoginProfileViewController.swift
+++ b/Flicker/Screens/SignUp/LoginProfileViewController.swift
@@ -175,7 +175,7 @@ final class LoginProfileViewController: BaseViewController {
 
         nickNameCountLabel.snp.makeConstraints {
             $0.centerY.equalTo(nickNameField.snp.centerY)
-            $0.leading.equalTo(nickNameField.snp.trailing)
+            $0.leading.equalTo(nickNameField.snp.trailing).offset(-10)
         }
 
         nickNameTextFieldClearButton.snp.makeConstraints {

--- a/Flicker/Screens/SignUp/LoginProfileViewController.swift
+++ b/Flicker/Screens/SignUp/LoginProfileViewController.swift
@@ -114,7 +114,7 @@ final class LoginProfileViewController: BaseViewController {
     }
 
     private let signUpButton = UIButton().then {
-        $0.backgroundColor = .loginGray
+        $0.backgroundColor = .systemGray2
         $0.setTitleColor(.white, for: .normal)
         $0.setTitle("완료", for: .normal)
         $0.layer.cornerRadius = DeviceFrame.screenHeight * 0.014
@@ -248,7 +248,7 @@ final class LoginProfileViewController: BaseViewController {
             signUpButton.backgroundColor = .mainPink
         } else {
             signUpButton.isEnabled = false
-            signUpButton.backgroundColor = .loginGray
+            signUpButton.backgroundColor = .systemGray2
         }
 
         isTapArtistButton = true
@@ -265,7 +265,7 @@ final class LoginProfileViewController: BaseViewController {
             signUpButton.backgroundColor = .mainPink
         } else {
             signUpButton.isEnabled = false
-            signUpButton.backgroundColor = .loginGray
+            signUpButton.backgroundColor = .systemGray2
         }
 
         isTapArtistButton = true
@@ -308,7 +308,7 @@ final class LoginProfileViewController: BaseViewController {
 
         if isTapArtistButton {
             signUpButton.isEnabled = false
-            signUpButton.backgroundColor = .loginGray
+            signUpButton.backgroundColor = .systemGray2
         }
     }
 
@@ -357,7 +357,7 @@ extension LoginProfileViewController: UIImagePickerControllerDelegate, UINavigat
 
         signUpButton.isEnabled = nickNameField.text!.isEmpty ? false : true
 
-        signUpButton.backgroundColor = (!nickNameField.text!.isEmpty && isTapArtistButton) ? .mainPink : .loginGray
+        signUpButton.backgroundColor = (!nickNameField.text!.isEmpty && isTapArtistButton) ? .mainPink : .systemGray2
     }
     override func textFieldDidEndEditing(_ textField: UITextField) {
         if !nickNameField.text!.isEmpty {
@@ -365,7 +365,7 @@ extension LoginProfileViewController: UIImagePickerControllerDelegate, UINavigat
             nickNameTextFieldClearButton.isHidden = true
 
             signUpButton.isEnabled = isTapArtistButton ? true : false
-            signUpButton.backgroundColor = isTapArtistButton ? .mainPink : .loginGray
+            signUpButton.backgroundColor = isTapArtistButton ? .mainPink : .systemGray2
 
         }
 

--- a/Flicker/Screens/SignUp/LoginProfileViewController.swift
+++ b/Flicker/Screens/SignUp/LoginProfileViewController.swift
@@ -103,21 +103,21 @@ final class LoginProfileViewController: BaseViewController {
         $0.setTitle("네", for: .normal)
         $0.backgroundColor = .loginGray
         $0.setTitleColor(.black, for: .normal)
-        $0.layer.cornerRadius = 10
+        $0.layer.cornerRadius = DeviceFrame.screenHeight * 0.012
     }
 
     private let artistFalseButton = UIButton().then {
         $0.setTitle("아니오", for: .normal)
         $0.backgroundColor = .loginGray
         $0.setTitleColor(.black, for: .normal)
-        $0.layer.cornerRadius = 10
+        $0.layer.cornerRadius = DeviceFrame.screenHeight * 0.012
     }
 
     private let signUpButton = UIButton().then {
         $0.backgroundColor = .loginGray
         $0.setTitleColor(.white, for: .normal)
         $0.setTitle("완료", for: .normal)
-        $0.layer.cornerRadius = 15
+        $0.layer.cornerRadius = DeviceFrame.screenHeight * 0.014
     }
 
     private let nickNameDivider = UIView().then {

--- a/Flicker/Screens/SignUp/SignUpViewController.swift
+++ b/Flicker/Screens/SignUp/SignUpViewController.swift
@@ -132,7 +132,7 @@ final class SignUpViewController: BaseViewController {
         }
 
         passwordField.snp.makeConstraints {
-            $0.top.equalTo(emailField.snp.bottom).offset(45)
+            $0.top.equalTo(emailField.snp.bottom).offset(35)
             $0.leading.trailing.equalToSuperview().inset(20)
             $0.height.equalTo(60)
         }
@@ -143,7 +143,7 @@ final class SignUpViewController: BaseViewController {
         }
 
         passwordSameCheckField.snp.makeConstraints {
-            $0.top.equalTo(passwordField.snp.bottom).offset(45)
+            $0.top.equalTo(passwordField.snp.bottom).offset(35)
             $0.leading.trailing.equalToSuperview().inset(20)
             $0.height.equalTo(60)
         }

--- a/Flicker/Screens/SignUp/SignUpViewController.swift
+++ b/Flicker/Screens/SignUp/SignUpViewController.swift
@@ -14,11 +14,11 @@ final class SignUpViewController: BaseViewController {
 
     private let didTapSignUpEmail = true
 
-    private let signUpTitleLabel = UILabel().makeBasicLabel(labelText: "반가워요!", textColor: .black, fontStyle: .largeTitle, fontWeight: .bold)
+    private let signUpTitleLabel = UILabel().makeBasicLabel(labelText: "반가워요!", textColor: .mainPink, fontStyle: .largeTitle, fontWeight: .bold)
 
 
     private let signUpLabel = UILabel().then {
-        $0.tintColor = .black
+        $0.tintColor = .textSubBlack
         $0.font = .preferredFont(forTextStyle: .title3, weight: .semibold)
         $0.numberOfLines = 2
         $0.text = "로그인에 사용될 이메일과 비밀번호를 설정해주세요"
@@ -44,7 +44,7 @@ final class SignUpViewController: BaseViewController {
 
     }
 
-    private let emailValidCheckLabel = UILabel().makeBasicLabel(labelText: "이메일 주소를 확인해 주세요.", textColor: .red, fontStyle: .subheadline, fontWeight: .light)
+    private let emailValidCheckLabel = UILabel().makeBasicLabel(labelText: "이메일 주소를 확인해 주세요.", textColor: .red, fontStyle: .caption1, fontWeight: .light)
 
     private let passwordField = UITextField().then {
         let attributes = [
@@ -52,7 +52,7 @@ final class SignUpViewController: BaseViewController {
             NSAttributedString.Key.font : UIFont.systemFont(ofSize: 17, weight: .bold)
         ]
         $0.tag = 1
-        $0.backgroundColor = .loginGray
+        $0.backgroundColor = .systemGray3
         $0.attributedPlaceholder = NSAttributedString(string: "비밀번호 (최소 6자 이상)", attributes: attributes)
         $0.layer.cornerRadius = DeviceFrame.screenHeight * 0.018
         $0.layer.masksToBounds = true
@@ -64,7 +64,7 @@ final class SignUpViewController: BaseViewController {
         $0.autocorrectionType = .no
     }
 
-    private let passwordValidCheckLabel = UILabel().makeBasicLabel(labelText: "비밀번호는 6자리 이상으로 작성해주세요.", textColor: .red, fontStyle: .subheadline, fontWeight: .light)
+    private let passwordValidCheckLabel = UILabel().makeBasicLabel(labelText: "비밀번호는 6자리 이상으로 작성해주세요.", textColor: .red, fontStyle: .caption1, fontWeight: .light)
 
     private let passwordSameCheckField = UITextField().then {
         let attributes = [
@@ -72,7 +72,7 @@ final class SignUpViewController: BaseViewController {
             NSAttributedString.Key.font : UIFont.systemFont(ofSize: 17, weight: .bold)
         ]
         $0.tag = 2
-        $0.backgroundColor = .loginGray
+        $0.backgroundColor = .systemGray3
         $0.attributedPlaceholder = NSAttributedString(string: "비밀번호 확인", attributes: attributes)
         $0.layer.cornerRadius = DeviceFrame.screenHeight * 0.018
         $0.layer.masksToBounds = true
@@ -84,10 +84,10 @@ final class SignUpViewController: BaseViewController {
         $0.autocorrectionType = .no
     }
 
-    private let passwordSameCheckLabel = UILabel().makeBasicLabel(labelText: "비밀번호가 일치하지 않습니다.", textColor: .red, fontStyle: .subheadline, fontWeight: .light)
+    private let passwordSameCheckLabel = UILabel().makeBasicLabel(labelText: "비밀번호가 일치하지 않습니다.", textColor: .red, fontStyle: .caption1, fontWeight: .light)
 
     private lazy var signUpButton = UIButton().then {
-        $0.backgroundColor = .loginGray
+        $0.backgroundColor = .systemGray2
         $0.setTitleColor(.white, for: .normal)
         $0.setTitle("다음", for: .normal)
         $0.layer.cornerRadius = DeviceFrame.screenHeight * 0.024
@@ -110,14 +110,14 @@ final class SignUpViewController: BaseViewController {
         view.addSubviews(emailValidCheckLabel ,signUpTitleLabel, signUpLabel, emailField, passwordField, signUpButton, passwordSameCheckField, passwordValidCheckLabel, passwordSameCheckLabel)
 
         signUpTitleLabel.snp.makeConstraints {
-            $0.top.equalTo(view.safeAreaLayoutGuide.snp.top).offset(50)
+            $0.top.equalTo(view.safeAreaLayoutGuide.snp.top).offset(40)
             $0.leading.equalToSuperview().inset(30)
         }
 
         signUpLabel.snp.makeConstraints {
             $0.top.equalTo(signUpTitleLabel.snp.bottom).offset(10)
             $0.leading.equalToSuperview().inset(30)
-            $0.width.equalTo(DeviceFrame.screenWidth * 0.63)
+            $0.width.equalTo(DeviceFrame.screenWidth * 0.65)
         }
 
         emailField.snp.makeConstraints {
@@ -143,7 +143,7 @@ final class SignUpViewController: BaseViewController {
         }
 
         passwordSameCheckField.snp.makeConstraints {
-            $0.top.equalTo(passwordField.snp.bottom).offset(35)
+            $0.top.equalTo(passwordField.snp.bottom).offset(30)
             $0.leading.trailing.equalToSuperview().inset(20)
             $0.height.equalTo(DeviceFrame.screenHeight * 0.07)
         }
@@ -220,7 +220,7 @@ extension SignUpViewController {
         if ( emailValidCheck(emailField) && passwordValidCheck(passwordField) && passwordSameCheck(passwordField, passwordSameCheckField)) {
             signUpButton.backgroundColor = .mainPink
         } else {
-            signUpButton.backgroundColor = .loginGray
+            signUpButton.backgroundColor = .systemGray2
         }
     }
 }

--- a/Flicker/Screens/SignUp/SignUpViewController.swift
+++ b/Flicker/Screens/SignUp/SignUpViewController.swift
@@ -117,7 +117,7 @@ final class SignUpViewController: BaseViewController {
         signUpLabel.snp.makeConstraints {
             $0.top.equalTo(signUpTitleLabel.snp.bottom).offset(10)
             $0.leading.equalToSuperview().inset(30)
-            $0.width.equalTo(250)
+            $0.width.equalTo(DeviceFrame.screenWidth * 0.63)
         }
 
         emailField.snp.makeConstraints {
@@ -156,7 +156,7 @@ final class SignUpViewController: BaseViewController {
         signUpButton.snp.makeConstraints {
             $0.bottom.equalTo(view.safeAreaLayoutGuide.snp.bottom).inset(50)
             $0.leading.trailing.equalToSuperview().inset(20)
-            $0.height.equalTo(55)
+            $0.height.equalTo(DeviceFrame.screenHeight * 0.065)
         }
 
     }

--- a/Flicker/Screens/SignUp/SignUpViewController.swift
+++ b/Flicker/Screens/SignUp/SignUpViewController.swift
@@ -123,7 +123,7 @@ final class SignUpViewController: BaseViewController {
         emailField.snp.makeConstraints {
             $0.top.equalTo(signUpLabel.snp.bottom).offset(30)
             $0.leading.trailing.equalToSuperview().inset(20)
-            $0.height.equalTo(60)
+            $0.height.equalTo(DeviceFrame.screenHeight * 0.07)
         }
 
         emailValidCheckLabel.snp.makeConstraints {
@@ -134,7 +134,7 @@ final class SignUpViewController: BaseViewController {
         passwordField.snp.makeConstraints {
             $0.top.equalTo(emailField.snp.bottom).offset(35)
             $0.leading.trailing.equalToSuperview().inset(20)
-            $0.height.equalTo(60)
+            $0.height.equalTo(DeviceFrame.screenHeight * 0.07)
         }
 
         passwordValidCheckLabel.snp.makeConstraints {
@@ -145,7 +145,7 @@ final class SignUpViewController: BaseViewController {
         passwordSameCheckField.snp.makeConstraints {
             $0.top.equalTo(passwordField.snp.bottom).offset(35)
             $0.leading.trailing.equalToSuperview().inset(20)
-            $0.height.equalTo(60)
+            $0.height.equalTo(DeviceFrame.screenHeight * 0.07)
         }
 
         passwordSameCheckLabel.snp.makeConstraints {

--- a/Flicker/Screens/SignUp/SignUpViewController.swift
+++ b/Flicker/Screens/SignUp/SignUpViewController.swift
@@ -34,7 +34,7 @@ final class SignUpViewController: BaseViewController {
         $0.backgroundColor = .loginGray
         $0.attributedPlaceholder = NSAttributedString(string: "이메일 주소", attributes: attributes)
         $0.autocapitalizationType = .none
-        $0.layer.cornerRadius = 12
+        $0.layer.cornerRadius = DeviceFrame.screenHeight * 0.018
         $0.layer.masksToBounds = true
         $0.leftView = UIView(frame: CGRect(x: 0, y: 0, width: 20, height: 0))
         $0.leftViewMode = .always
@@ -54,7 +54,7 @@ final class SignUpViewController: BaseViewController {
         $0.tag = 1
         $0.backgroundColor = .loginGray
         $0.attributedPlaceholder = NSAttributedString(string: "비밀번호 (최소 6자 이상)", attributes: attributes)
-        $0.layer.cornerRadius = 12
+        $0.layer.cornerRadius = DeviceFrame.screenHeight * 0.018
         $0.layer.masksToBounds = true
         $0.leftView = UIView(frame: CGRect(x: 0, y: 0, width: 20, height: 0))
         $0.leftViewMode = .always
@@ -74,7 +74,7 @@ final class SignUpViewController: BaseViewController {
         $0.tag = 2
         $0.backgroundColor = .loginGray
         $0.attributedPlaceholder = NSAttributedString(string: "비밀번호 확인", attributes: attributes)
-        $0.layer.cornerRadius = 12
+        $0.layer.cornerRadius = DeviceFrame.screenHeight * 0.018
         $0.layer.masksToBounds = true
         $0.leftView = UIView(frame: CGRect(x: 0, y: 0, width: 20, height: 0))
         $0.leftViewMode = .always
@@ -90,7 +90,7 @@ final class SignUpViewController: BaseViewController {
         $0.backgroundColor = .loginGray
         $0.setTitleColor(.white, for: .normal)
         $0.setTitle("다음", for: .normal)
-        $0.layer.cornerRadius = 20
+        $0.layer.cornerRadius = DeviceFrame.screenHeight * 0.024
         $0.addTarget(self, action: #selector(didTapSignUpButton), for: .touchUpInside)
     }
 

--- a/Flicker/Screens/WithDraw/WithDrawViewController.swift
+++ b/Flicker/Screens/WithDraw/WithDrawViewController.swift
@@ -16,10 +16,6 @@ import FirebaseFirestore
 
 final class WithDrawViewController: BaseViewController {
     
-    private let navigationDivider = UIView().then {
-        $0.backgroundColor = .loginGray
-    }
-    
     private let mainLabel = UILabel().makeBasicLabel(labelText: "고마웠어요!", textColor: .textMainBlack, fontStyle: .largeTitle, fontWeight: .bold)
     
     private let subLabel = UILabel().makeBasicLabel(labelText: "순간을 기념하고 싶을 때 언제든 다시 찾아주세요!", textColor: .textSubBlack, fontStyle: .title3, fontWeight: .bold).then {
@@ -37,31 +33,26 @@ final class WithDrawViewController: BaseViewController {
         $0.backgroundColor = .mainPink
         $0.setTitleColor(.white, for: .normal)
         $0.setTitle("로그인화면으로 돌아가기", for: .normal)
-        $0.layer.cornerRadius = 15
+        $0.layer.cornerRadius = (DeviceFrame.screenHeight * 0.077) * 0.35
     }
     
     override func render() {
         
-        view.addSubviews(navigationDivider, mainLabel, subLabel, titleLabel, signOutButton)
+        view.addSubviews(mainLabel, subLabel, titleLabel, signOutButton)
         
         signOutButton.addTarget(self, action: #selector(didTapSignInbutton), for: .touchUpInside)
-        
-        navigationDivider.snp.makeConstraints {
-            $0.top.equalTo(view.safeAreaLayoutGuide.snp.top)
-            $0.leading.trailing.equalToSuperview()
-            $0.height.equalTo(2)
-        }
+
         
         mainLabel.snp.makeConstraints {
-            $0.top.equalTo(navigationDivider.snp.bottom).offset(170)
+            $0.top.equalTo(view.safeAreaLayoutGuide.snp.top).offset(180)
             $0.leading.equalToSuperview().inset(45)
         }
         
         subLabel.snp.makeConstraints {
             $0.top.equalTo(mainLabel.snp.bottom).offset(5)
             $0.leading.equalToSuperview().inset(45)
-            $0.width.equalTo(220)
-            $0.height.equalTo(60)
+            $0.width.equalTo(DeviceFrame.screenWidth * 0.64)
+            $0.height.equalTo(DeviceFrame.screenHeight * 0.08)
         }
         
         titleLabel.snp.makeConstraints {
@@ -72,7 +63,7 @@ final class WithDrawViewController: BaseViewController {
         signOutButton.snp.makeConstraints {
             $0.bottom.equalTo(view.safeAreaLayoutGuide.snp.bottom).inset(50)
             $0.leading.trailing.equalToSuperview().inset(20)
-            $0.height.equalTo(65)
+            $0.height.equalTo(DeviceFrame.screenHeight * 0.077)
         }
     }
     


### PR DESCRIPTION
## 🌁 배경
- 피파의 디자인 수정 및 맡은 뷰에 한해서 각 기기별 대응을 할 수 있도록 코드를 수정했습니다.

## 👩‍💻 작업 내용 (Content)
- StaticValue로 디바이스의 높이와 너비를 추가했습니다.
- 그래서 각 고정값으로 되어있던 높이 와 너비 값들을 기기별로 비례해서 구현되도록 변경하였습니다.
- 동영상 두개는 기기별 호환여부를 중점으로 보시면 되며, 하단의 GIF는 디자인을 보시면 됩니다.

## 📱 스크린샷
- 아이폰 SE3세대

https://user-images.githubusercontent.com/81131715/204472690-f8039f4d-e0d9-4626-91f1-1c4f249fab6c.mp4

- 아이폰 14proMAX

https://user-images.githubusercontent.com/81131715/204472679-8e3d4658-abef-4f12-94ad-61b672b65567.mp4

- 마지막 커밋 수정본
![Simulator Screen Recording - iPhone 14 Pro - 2022-11-29 at 17 47 38](https://user-images.githubusercontent.com/81131715/204482121-32c286c7-6620-4b18-b249-b6904b4fee02.gif)



## 📣 PR & Issues
- 현재 작성 중인 Pull Request와 관련된 PR과 Issues가 있다면 나열합니다.
- closed #170