### PR TITLE
✨ 작가의 정보 중 포트폴리오(이미지) 를 수정할 수 있습니다.

### DIFF
--- a/Flicker.xcodeproj/project.pbxproj
+++ b/Flicker.xcodeproj/project.pbxproj
@@ -24,6 +24,7 @@
 		58118D4D29116B5400F08D35 /* RegisterRegionTagCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 58118D4C29116B5400F08D35 /* RegisterRegionTagCell.swift */; };
 		58118D4F29116B8B00F08D35 /* LeftAlignedCollectionViewFlowLayout.swift in Sources */ = {isa = PBXBuildFile; fileRef = 58118D4E29116B8B00F08D35 /* LeftAlignedCollectionViewFlowLayout.swift */; };
 		5819EE5029236EEE000077D7 /* Artist.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5819EE4F29236EEE000077D7 /* Artist.swift */; };
+		582EDE1A2935FCBD00E44035 /* EditData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 582EDE192935FCBD00E44035 /* EditData.swift */; };
 		5833A775291A48820077855F /* RegisterPortfolioImageCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5833A774291A48820077855F /* RegisterPortfolioImageCell.swift */; };
 		5833A779291A66FF0077855F /* RegisterAddPhotosCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5833A778291A66FF0077855F /* RegisterAddPhotosCollectionViewCell.swift */; };
 		58A20CE9292C8C840036A474 /* ArtistEditRegionsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 58A20CE8292C8C840036A474 /* ArtistEditRegionsViewController.swift */; };
@@ -119,6 +120,7 @@
 		58118D4C29116B5400F08D35 /* RegisterRegionTagCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RegisterRegionTagCell.swift; sourceTree = "<group>"; };
 		58118D4E29116B8B00F08D35 /* LeftAlignedCollectionViewFlowLayout.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LeftAlignedCollectionViewFlowLayout.swift; sourceTree = "<group>"; };
 		5819EE4F29236EEE000077D7 /* Artist.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Artist.swift; sourceTree = "<group>"; };
+		582EDE192935FCBD00E44035 /* EditData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditData.swift; sourceTree = "<group>"; };
 		5833A774291A48820077855F /* RegisterPortfolioImageCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RegisterPortfolioImageCell.swift; sourceTree = "<group>"; };
 		5833A778291A66FF0077855F /* RegisterAddPhotosCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RegisterAddPhotosCollectionViewCell.swift; sourceTree = "<group>"; };
 		58A20CE8292C8C840036A474 /* ArtistEditRegionsViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ArtistEditRegionsViewController.swift; sourceTree = "<group>"; };
@@ -600,6 +602,7 @@
 				CB5BF47C2919E15300A3E112 /* RecentMessage.swift */,
 				CB5BF47D2919E15400A3E112 /* User.swift */,
 				5819EE4F29236EEE000077D7 /* Artist.swift */,
+				582EDE192935FCBD00E44035 /* EditData.swift */,
 			);
 			path = Models;
 			sourceTree = "<group>";
@@ -833,6 +836,7 @@
 				CBDC043A2906143200C6CF30 /* TabbarViewController.swift in Sources */,
 				58DCC900292B76F900A2C644 /* ArtistEditViewController.swift in Sources */,
 				CB5BF4842919E1A800A3E112 /* SendButton.swift in Sources */,
+				582EDE1A2935FCBD00E44035 /* EditData.swift in Sources */,
 				CB5BF4762919E10700A3E112 /* MyChatTableViewCell.swift in Sources */,
 				CBDC03D629060E6600C6CF30 /* SceneDelegate.swift in Sources */,
 				58A452AD2912A26F00C9707D /* RegisterConfirmViewController.swift in Sources */,

--- a/Flicker/Global/Supports/SceneDelegate.swift
+++ b/Flicker/Global/Supports/SceneDelegate.swift
@@ -17,10 +17,10 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         guard let windowScene = (scene as? UIWindowScene) else { return }
         window = UIWindow(windowScene: windowScene)
 
-        let AuthController = UINavigationController(rootViewController: LogInViewController())
-//
-        window?.rootViewController = ( Auth.auth().currentUser != nil && UserDefaults.standard.string(forKey: "userEmail") != nil ) ? TabbarViewController() : AuthController
-//        window?.rootViewController = UINavigationController(rootViewController: ArtistEditViewController())
+//        let AuthController = UINavigationController(rootViewController: LogInViewController())
+////
+//        window?.rootViewController = ( Auth.auth().currentUser != nil && UserDefaults.standard.string(forKey: "userEmail") != nil ) ? TabbarViewController() : AuthController
+        window?.rootViewController = UINavigationController(rootViewController: ArtistEditViewController())
         
         window?.makeKeyAndVisible()
     }

--- a/Flicker/Global/Supports/SceneDelegate.swift
+++ b/Flicker/Global/Supports/SceneDelegate.swift
@@ -17,10 +17,9 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         guard let windowScene = (scene as? UIWindowScene) else { return }
         window = UIWindow(windowScene: windowScene)
 
-//        let AuthController = UINavigationController(rootViewController: LogInViewController())
-////
-//        window?.rootViewController = ( Auth.auth().currentUser != nil && UserDefaults.standard.string(forKey: "userEmail") != nil ) ? TabbarViewController() : AuthController
-        window?.rootViewController = UINavigationController(rootViewController: ArtistEditViewController())
+        let AuthController = UINavigationController(rootViewController: LogInViewController())
+        window?.rootViewController = ( Auth.auth().currentUser != nil && UserDefaults.standard.string(forKey: "userEmail") != nil ) ? TabbarViewController() : AuthController
+//        window?.rootViewController = UINavigationController(rootViewController: ArtistEditViewController())
         
         window?.makeKeyAndVisible()
     }

--- a/Flicker/Global/Utils/FirebaseManager.swift
+++ b/Flicker/Global/Utils/FirebaseManager.swift
@@ -129,7 +129,7 @@ final class FirebaseManager: NSObject {
         }
     }
     
-    // TODO: - 여기서 uid 어떻게 사용해야하나??? 이거만 처리하면 얼추 처리 된듯? + Task 그 이미지 처리하는 거 잘 붙여 넣고, Task 처리 잘하고... 그리고 테스트를 위해서 붙였던 등록 맨 끝 뒤에 바로 에디트뷰로 옮긴거 잘 해놓자.
+    // TODO: - 여기서 uid 어떻게 사용해야하나??? 이거만 처리하면 얼추 처리 된듯? ✅ + Task 그 이미지 처리하는 거 잘 붙여 넣고, Task 처리 잘하고... 그리고 테스트를 위해서 붙였던 등록 맨 끝 뒤에 바로 에디트뷰로 옮긴거 잘 해놓자.
     func getArtists() async -> Artist? {
         guard let uid = auth.currentUser?.uid else { return nil }
         do {
@@ -163,7 +163,6 @@ final class FirebaseManager: NSObject {
             return nil
         }
     }
-
     
     func createChatMessage(currentUser: User, chatUser: User, chatText: String) {
         

--- a/Flicker/Global/Utils/FirebaseManager.swift
+++ b/Flicker/Global/Utils/FirebaseManager.swift
@@ -146,6 +146,17 @@ final class FirebaseManager: NSObject {
         }
     }
     
+    func removeImages(urlCount: Int) async {
+        guard let uid = auth.currentUser?.uid else { return }
+        do {
+            var fileName = uid + "_" + String(urlCount)
+            let deleteRef = storage.reference().child("ArtistPortfolio/\(fileName).jpg")
+            try await deleteRef.delete()
+        } catch {
+            print(error)
+        }
+    }
+    
 /*파이어 베이스에서 Email필드에 값을 불러오는데 서치 값이 없을 경우 빈 배열을 불러온다. 빈 배열일 경우 사용자가 적은 이메일 값이
  없고, 배열에 값이 존재할 경우 사용자가 사용하려는 이메일은 이미 존재함을 의미한다. */
     func isEmailSameExist(Email: String) async -> Bool? {
@@ -290,6 +301,19 @@ final class FirebaseManager: NSObject {
         guard let uid = auth.currentUser?.uid else { return }
         do {
             let artistData = ["state": artist.state, "regions": artist.regions, "camera": artist.camera, "lens": artist.lens, "tags": artist.tags, "detailDescription": artist.detailDescription, "portfolioImageUrls":  artist.portfolioImageUrls.sorted(), "userInfo": artist.userInfo] as [String : Any]
+            try await firestore.collection("artists").document(uid).setData(artistData)
+            print("⭐️⭐️⭐️URL UPLOAD DONE ⭐️⭐️⭐️")
+        } catch {
+            print("error string Artist Model")
+        }
+    }
+    
+    // 일단 setData 로 하는데 안 건든 부분은 없어지는 것인가? 아니면 업데이트 되지 않고 남아있는 것인가?
+    func updateArtistInformation(_ artist: EditData) async {
+        guard let uid = auth.currentUser?.uid else { return }
+        let userDefaultInfo = UserDefaults.standard.getObjects(forKeys: ["userEmail", "userName", "userProfileImageUrl", "userToken", "userId"])
+        do {
+            let artistData = ["state": "전체", "regions": artist.regions, "camera": artist.camera, "lens": artist.lens, "tags": artist.tags, "detailDescription": artist.detailDescription, "portfolioImageUrls":  artist.portfolioUrls.sorted(), "userInfo": userDefaultInfo] as [String : Any]
             try await firestore.collection("artists").document(uid).setData(artistData)
             print("⭐️⭐️⭐️URL UPLOAD DONE ⭐️⭐️⭐️")
         } catch {

--- a/Flicker/Global/Utils/FirebaseManager.swift
+++ b/Flicker/Global/Utils/FirebaseManager.swift
@@ -129,8 +129,9 @@ final class FirebaseManager: NSObject {
         }
     }
     
+    // TODO: - 여기서 uid 어떻게 사용해야하나??? 이거만 처리하면 얼추 처리 된듯? + Task 그 이미지 처리하는 거 잘 붙여 넣고, Task 처리 잘하고... 그리고 테스트를 위해서 붙였던 등록 맨 끝 뒤에 바로 에디트뷰로 옮긴거 잘 해놓자.
     func getArtists() async -> Artist? {
-//        guard let uid = auth.currentUser?.uid else { return nil }
+//        guard let uid = auth.currentUser?.uid else { return nil } ⭐️
         do {
             var downloadedArtist = Artist(regions: [], camera: "", lens: "", tags: [], detailDescription: "", portfolioImageUrls: [], userInfo: [:])
             

--- a/Flicker/Global/Utils/FirebaseManager.swift
+++ b/Flicker/Global/Utils/FirebaseManager.swift
@@ -131,20 +131,17 @@ final class FirebaseManager: NSObject {
     
     // TODO: - 여기서 uid 어떻게 사용해야하나??? 이거만 처리하면 얼추 처리 된듯? + Task 그 이미지 처리하는 거 잘 붙여 넣고, Task 처리 잘하고... 그리고 테스트를 위해서 붙였던 등록 맨 끝 뒤에 바로 에디트뷰로 옮긴거 잘 해놓자.
     func getArtists() async -> Artist? {
-//        guard let uid = auth.currentUser?.uid else { return nil } ⭐️
+        guard let uid = auth.currentUser?.uid else { return nil }
         do {
             var downloadedArtist = Artist(regions: [], camera: "", lens: "", tags: [], detailDescription: "", portfolioImageUrls: [], userInfo: [:])
-            
-            let documentsSnapshot = try await firestore.collection("artists").getDocuments()
-            
-            await documentsSnapshot.documents.asyncForEach({ snapshot in
-                guard let artist = try? snapshot.data(as: Artist.self) else { return }
-                downloadedArtist = artist
-            })
-            
+            let documentsSnapshot = try await firestore.collection("artists").document(uid).getDocument()
+            let artistFetched = try documentsSnapshot.data(as: Artist.self)
+            downloadedArtist = artistFetched
+
             return downloadedArtist
         } catch {
             print(error)
+            
             return nil
         }
     }

--- a/Flicker/Global/Utils/FirebaseManager.swift
+++ b/Flicker/Global/Utils/FirebaseManager.swift
@@ -129,7 +129,7 @@ final class FirebaseManager: NSObject {
         }
     }
     
-    // TODO: - 여기서 uid 어떻게 사용해야하나??? 이거만 처리하면 얼추 처리 된듯? ✅ + Task 그 이미지 처리하는 거 잘 붙여 넣고, Task 처리 잘하고... 그리고 테스트를 위해서 붙였던 등록 맨 끝 뒤에 바로 에디트뷰로 옮긴거 잘 해놓자.
+    // MARK: - get Artist Datas for update
     func getArtists() async -> Artist? {
         guard let uid = auth.currentUser?.uid else { return nil }
         do {
@@ -146,10 +146,11 @@ final class FirebaseManager: NSObject {
         }
     }
     
+    // MARK: - remove Images with downloadUrl index numbers
     func removeImages(urlCount: Int) async {
         guard let uid = auth.currentUser?.uid else { return }
         do {
-            var fileName = uid + "_" + String(urlCount)
+            let fileName = uid + "_" + String(urlCount)
             let deleteRef = storage.reference().child("ArtistPortfolio/\(fileName).jpg")
             try await deleteRef.delete()
         } catch {
@@ -308,7 +309,7 @@ final class FirebaseManager: NSObject {
         }
     }
     
-    // 일단 setData 로 하는데 안 건든 부분은 없어지는 것인가? 아니면 업데이트 되지 않고 남아있는 것인가?
+    // MARK: - updating Artist Data using EditData
     func updateArtistInformation(_ artist: EditData) async {
         guard let uid = auth.currentUser?.uid else { return }
         let userDefaultInfo = UserDefaults.standard.getObjects(forKeys: ["userEmail", "userName", "userProfileImageUrl", "userToken", "userId"])

--- a/Flicker/Global/Utils/FirebaseManager.swift
+++ b/Flicker/Global/Utils/FirebaseManager.swift
@@ -128,6 +128,26 @@ final class FirebaseManager: NSObject {
             return nil
         }
     }
+    
+    func getArtists() async -> Artist? {
+//        guard let uid = auth.currentUser?.uid else { return nil }
+        do {
+            var downloadedArtist = Artist(regions: [], camera: "", lens: "", tags: [], detailDescription: "", portfolioImageUrls: [], userInfo: [:])
+            
+            let documentsSnapshot = try await firestore.collection("artists").getDocuments()
+            
+            await documentsSnapshot.documents.asyncForEach({ snapshot in
+                guard let artist = try? snapshot.data(as: Artist.self) else { return }
+                downloadedArtist = artist
+            })
+            
+            return downloadedArtist
+        } catch {
+            print(error)
+            return nil
+        }
+    }
+    
 /*파이어 베이스에서 Email필드에 값을 불러오는데 서치 값이 없을 경우 빈 배열을 불러온다. 빈 배열일 경우 사용자가 적은 이메일 값이
  없고, 배열에 값이 존재할 경우 사용자가 사용하려는 이메일은 이미 존재함을 의미한다. */
     func isEmailSameExist(Email: String) async -> Bool? {

--- a/Flicker/Models/EditData.swift
+++ b/Flicker/Models/EditData.swift
@@ -1,0 +1,19 @@
+//
+//  EditData.swift
+//  Flicker
+//
+//  Created by KYUBO A. SHIM on 2022/11/29.
+//
+
+import UIKit
+
+// MARK: - New Data set for Editing Views
+struct EditData: Equatable {
+    var regions: [String]
+    var camera: String
+    var lens: String
+    var tags: [String]
+    var detailDescription: String
+    var portfolioImages: [UIImage]
+    var portfolioUrls: [String]
+}

--- a/Flicker/Models/User.swift
+++ b/Flicker/Models/User.swift
@@ -36,5 +36,6 @@ final class CurrentUserDataManager {
         defaults.removeObject(forKey: "userToken")
         defaults.removeObject(forKey: "regions")
         defaults.removeObject(forKey: "state")
+        defaults.removeObject(forKey: "isArtist")
     }
 }

--- a/Flicker/Screens/ArtistEdit/Cell/ArtistEditItemsTableViewCell.swift
+++ b/Flicker/Screens/ArtistEdit/Cell/ArtistEditItemsTableViewCell.swift
@@ -11,6 +11,7 @@ import Then
 
 class ArtistEditItemsTableViewCell: UITableViewCell {
     
+    // MARK: - view UI components
     let cellTextLabel = UILabel().makeBasicLabel(labelText: "a", textColor: .textMainBlack.withAlphaComponent(0.8), fontStyle: .title3, fontWeight: .bold)
     
     lazy var cellImage = UIImageView().then {
@@ -33,6 +34,7 @@ class ArtistEditItemsTableViewCell: UITableViewCell {
         $0.isHidden = true
     }
     
+    // MARK: - bool for checking changes of the data
     var checkEditted: Bool = false {
         didSet {
             if oldValue == true {
@@ -43,6 +45,7 @@ class ArtistEditItemsTableViewCell: UITableViewCell {
         }
     }
     
+    // MARK: - life cycle
     override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
         super.init(style: style, reuseIdentifier: reuseIdentifier)
         self.backgroundColor = .mainPink.withAlphaComponent(0.1)
@@ -50,6 +53,7 @@ class ArtistEditItemsTableViewCell: UITableViewCell {
         configUI()
     }
     
+    // MARK: - layout constraints
     private func render() {
         self.addSubviews(cellImage, cellTextLabel, editButton, edittedLabel)
         
@@ -78,6 +82,7 @@ class ArtistEditItemsTableViewCell: UITableViewCell {
         }
     }
     
+    // MARK: - view configurations
     private func configUI() {
         self.selectionStyle = .none
     }

--- a/Flicker/Screens/ArtistEdit/ViewControllers/ArtistEditDescriptionViewController.swift
+++ b/Flicker/Screens/ArtistEdit/ViewControllers/ArtistEditDescriptionViewController.swift
@@ -74,7 +74,7 @@ final class ArtistEditDescriptionViewController: UIViewController {
     
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
-        descriptionTextView.text = self.currentInfo // 이게 @State 같은 느낌이랄까?
+        descriptionTextView.text = self.currentInfo
         self.navigationController?.setNavigationBarHidden(true, animated: false)
         self.customNavigationBarView.popImage.isHidden = true
     }
@@ -127,12 +127,19 @@ final class ArtistEditDescriptionViewController: UIViewController {
     }
     
     // MARK: - keyboard touch dismiss
-    
     override func touchesBegan(_ touches: Set<UITouch>, with event: UIEvent?) {
         self.view.endEditing(true)
     }
 }
 
+    // MARK: - textView delegate
+extension ArtistEditDescriptionViewController: UITextViewDelegate {
+    func textViewDidEndEditing(_ textView: UITextView) {
+        enableButton()
+    }
+}
+
+    // MARK: - action functions
 extension ArtistEditDescriptionViewController {
     private func customBackButton() {
         let backTapped = UITapGestureRecognizer(target: self, action: #selector(backButtonTapped))
@@ -153,6 +160,7 @@ extension ArtistEditDescriptionViewController {
         self.navigationController?.popViewController(animated: true)
     }
     
+    // MARK: enable disabled button under the condtion
     private func enableButton() {
         guard let descText = descriptionTextView.text else { return }
         if !descText.isEmpty {
@@ -165,13 +173,7 @@ extension ArtistEditDescriptionViewController {
     }
 }
 
-extension ArtistEditDescriptionViewController: UITextViewDelegate {
-    func textViewDidEndEditing(_ textView: UITextView) {
-        enableButton()
-    }
-}
-
-// MARK: - RegisterTextDescription custom delegate protocol
+// MARK: - Edit TextDescription custom delegate protocol
 protocol EditTextInfoDelegate: AnyObject {
     func textViewDescribed(textView textDescribed: String)
 }

--- a/Flicker/Screens/ArtistEdit/ViewControllers/ArtistEditGearsViewController.swift
+++ b/Flicker/Screens/ArtistEdit/ViewControllers/ArtistEditGearsViewController.swift
@@ -121,7 +121,6 @@ final class ArtistEditGearsViewController: UIViewController {
     }
     
     // MARK: - keyboard automatically pop
-    
     override func touchesBegan(_ touches: Set<UITouch>, with event: UIEvent?) {
         self.view.endEditing(true)
     }
@@ -224,6 +223,7 @@ extension ArtistEditGearsViewController: UITextFieldDelegate {
     }
 }
 
+    // MARK: - action functions
 extension ArtistEditGearsViewController {
     private func customBackButton() {
         let backTapped = UITapGestureRecognizer(target: self, action: #selector(backButtonTapped))
@@ -245,6 +245,7 @@ extension ArtistEditGearsViewController {
         self.navigationController?.popViewController(animated: true)
     }
     
+    // MARK: enable disabled button under the condtion
     private func enableButton() {
         guard let bodyText = cameraBodyTextField.text, let lensText = cameraLensTextField.text else { return }
         if !bodyText.isEmpty && !lensText.isEmpty {
@@ -257,7 +258,7 @@ extension ArtistEditGearsViewController {
     }
 }
 
-// MARK: - RegisterGears custom delegate protocol
+// MARK: - Edit Gears custom delegate protocol
 protocol EditGearsDelegate: AnyObject {
     func cameraBodySelected(cameraBody bodyName: String)
     func cameraLensSelected(cameraLens lensName: String)

--- a/Flicker/Screens/ArtistEdit/ViewControllers/ArtistEditPortfoiloViewController.swift
+++ b/Flicker/Screens/ArtistEdit/ViewControllers/ArtistEditPortfoiloViewController.swift
@@ -42,6 +42,15 @@ final class ArtistEditPortfoiloViewController: UIViewController {
         $0.isHidden = true
     }
     
+    private let completeEditButton = UIButton(type: .system).then {
+        $0.isEnabled = false
+        $0.tintColor = .white
+        $0.titleLabel?.font = UIFont.preferredFont(forTextStyle: .title3, weight: .semibold)
+        $0.backgroundColor = .systemGray2.withAlphaComponent(0.6)
+        $0.setTitle("사진 수정 완료", for: .normal)
+        $0.clipsToBounds = true
+    }
+    
     // MARK: - portfolio image components
     private var portfolioPhotosFetched: [UIImage] = []
         
@@ -67,15 +76,6 @@ final class ArtistEditPortfoiloViewController: UIViewController {
     private lazy var portfolioCollectionView = UICollectionView(frame: .zero, collectionViewLayout: portfolioFlowLayout).then {
         $0.showsVerticalScrollIndicator = false
         $0.isScrollEnabled = true
-    }
-    
-    private let completeEditButton = UIButton(type: .system).then {
-        $0.isEnabled = false
-        $0.tintColor = .white
-        $0.titleLabel?.font = UIFont.preferredFont(forTextStyle: .title3, weight: .semibold)
-        $0.backgroundColor = .systemGray2.withAlphaComponent(0.6)
-        $0.setTitle("장비 수정 완료", for: .normal)
-        $0.clipsToBounds = true
     }
     
     // MARK: - life cycle
@@ -243,6 +243,7 @@ extension ArtistEditPortfoiloViewController: UICollectionViewDelegate {
     }
 }
 
+    // MARK: - action functions
 extension ArtistEditPortfoiloViewController {
     private func customBackButton() {
         let backTapped = UITapGestureRecognizer(target: self, action: #selector(backButtonTapped))
@@ -263,6 +264,7 @@ extension ArtistEditPortfoiloViewController {
         self.navigationController?.popViewController(animated: true)
     }
     
+    // MARK: enable disabled button under the condtion
     private func enableButton() {
         if !portfolioPhotosFetched.isEmpty {
             completeEditButton.isEnabled = true
@@ -273,6 +275,7 @@ extension ArtistEditPortfoiloViewController {
         }
     }
     
+    // MARK: reset photos array
     private func resetData() {
         portfolioPhotosFetched = []
         portfolioCollectionView.reloadData()
@@ -280,7 +283,7 @@ extension ArtistEditPortfoiloViewController {
     }
 }
 
-// MARK: - RegisterPortfolio custom delegate protocol
+// MARK: - Edit Portfolio custom delegate protocol
 protocol EditPortfolioDelegate: AnyObject {
     func photoSelected(photos imagesPicked: [UIImage])
 }

--- a/Flicker/Screens/ArtistEdit/ViewControllers/ArtistEditPortfoiloViewController.swift
+++ b/Flicker/Screens/ArtistEdit/ViewControllers/ArtistEditPortfoiloViewController.swift
@@ -6,24 +6,281 @@
 //
 
 import UIKit
+import PhotosUI
+import SnapKit
+import Then
 
-class ArtistEditPortfoiloViewController: UIViewController {
-
-    override func viewDidLoad() {
-        super.viewDidLoad()
-
-        // Do any additional setup after loading the view.
+    // TODO: (다음 버전에..)
+final class ArtistEditPortfoiloViewController: UIViewController {
+    
+    // MARK: - custom delegate to send Datas
+    weak var delegate: EditPortfolioDelegate?
+    
+    // MARK: - custom navigation bar
+    private let customNavigationBarView = RegisterCustomNavigationView()
+    
+    // MARK: - view UI components
+    private let mainTitleLabel = UILabel().then {
+        $0.textColor = .systemTeal
+        $0.font = UIFont.preferredFont(forTextStyle: .largeTitle, weight: .bold)
+        $0.text = "포트폴리오 수정"
     }
     
-
-    /*
-    // MARK: - Navigation
-
-    // In a storyboard-based application, you will often want to do a little preparation before navigation
-    override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
-        // Get the new view controller using segue.destination.
-        // Pass the selected object to the new view controller.
+    private let subTitleLabel = UILabel().then {
+        $0.font = UIFont.preferredFont(forTextStyle: .title3, weight: .bold)
+        $0.text = "포트폴리오를 새롭게 수정해요!"
     }
-    */
+    
+    private let bodyTitleLabel = UILabel().then {
+        $0.numberOfLines = 3
+        $0.textColor = .systemGray
+        $0.font = UIFont.preferredFont(forTextStyle: .body, weight: .medium)
+        $0.text = "최대 12장까지 선택 가능하며, 등록된 사진들 중 사람들에게 가장 먼저 보여질 대표 사진을 눌러 정해보세요!"
+    }
+    
+    private let guideLabel = UILabel().makeBasicLabel(labelText: "사진을 탭해, 대표 사진을 바꿔보세요!", textColor: .red.withAlphaComponent(0.5), fontStyle: .subheadline, fontWeight: .medium).then {
+        $0.isHidden = true
+    }
+    
+    // MARK: - portfolio image components
+    private var portfolioPhotosFetched: [UIImage] = []
+        
+    private enum portfolioCellIdentifier: String {
+        case images = "portfoilo"
+        case addButton = "button"
+    }
+    
+    private let portfolioFlowLayout = UICollectionViewFlowLayout().then {
+        let imageWidth = (UIScreen.main.bounds.width - 80)/3
+        $0.itemSize = CGSize(width: imageWidth , height: imageWidth)
+        $0.minimumLineSpacing = 10
+    }
+    
+    private let portfolioPicker: PHPickerViewController = {
+        var photoConfiguration = PHPickerConfiguration()
+        photoConfiguration.selectionLimit = 12
+        photoConfiguration.filter = .images
+        let photoPicker = PHPickerViewController(configuration: photoConfiguration)
+        return photoPicker
+    }()
+    
+    private lazy var portfolioCollectionView = UICollectionView(frame: .zero, collectionViewLayout: portfolioFlowLayout).then {
+        $0.showsVerticalScrollIndicator = false
+        $0.isScrollEnabled = true
+    }
+    
+    private let completeEditButton = UIButton(type: .system).then {
+        $0.isEnabled = false
+        $0.tintColor = .white
+        $0.titleLabel?.font = UIFont.preferredFont(forTextStyle: .title3, weight: .semibold)
+        $0.backgroundColor = .systemGray2.withAlphaComponent(0.6)
+        $0.setTitle("장비 수정 완료", for: .normal)
+        $0.clipsToBounds = true
+    }
+    
+    // MARK: - life cycle
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        configUI()
+        render()
+        customBackButton()
+        completeButton()
+    }
+    
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        resetData()
+        self.navigationController?.setNavigationBarHidden(true, animated: false)
+        self.customNavigationBarView.popImage.isHidden = true
+    }
+    
+    //MARK: Guide label for changing main photo by tapping images
+    override func viewDidLayoutSubviews() {
+        super.viewDidLayoutSubviews()
+        if self.portfolioPhotosFetched.count > 0 {
+            self.guideLabel.isHidden = false
+        }
+    }
+    
+    // MARK: - layout constraints
+    private func render() {
+        view.addSubviews(customNavigationBarView, mainTitleLabel, subTitleLabel, bodyTitleLabel, guideLabel, portfolioCollectionView, completeEditButton)
+        
+        customNavigationBarView.snp.makeConstraints {
+            $0.top.leading.trailing.equalTo(self.view.safeAreaLayoutGuide)
+            $0.height.equalTo(view.bounds.height/16)
+        }
+        
+        mainTitleLabel.snp.makeConstraints {
+            $0.top.equalTo(customNavigationBarView.snp.bottom).offset(UIScreen.main.bounds.height/24)
+            $0.leading.equalToSuperview().inset(30)
+        }
+        
+        subTitleLabel.snp.makeConstraints {
+            $0.top.equalTo(mainTitleLabel.snp.bottom).offset(30)
+            $0.leading.equalToSuperview().inset(30)
+        }
+        
+        bodyTitleLabel.snp.makeConstraints {
+            $0.top.equalTo(subTitleLabel.snp.bottom).offset(5)
+            $0.leading.trailing.equalToSuperview().inset(30)
+        }
+        
+        guideLabel.snp.makeConstraints {
+            $0.top.equalTo(bodyTitleLabel.snp.bottom).offset(5)
+            $0.leading.equalToSuperview().inset(33)
+        }
+        
+        portfolioCollectionView.snp.makeConstraints {
+            $0.top.equalTo(bodyTitleLabel.snp.bottom).offset(30)
+            $0.leading.trailing.equalToSuperview().inset(30)
+            $0.bottom.equalToSuperview()
+        }
+        
+        completeEditButton.snp.makeConstraints {
+            $0.bottom.equalToSuperview().inset(UIScreen.main.bounds.height/13)
+            $0.leading.trailing.equalToSuperview().inset(20)
+            $0.height.equalTo(view.bounds.height/12)
+        }
+    }
+    
+    // MARK: - view configurations
+    private func configUI() {
+        view.backgroundColor = .systemBackground
+        
+        portfolioPicker.delegate = self
+        
+        portfolioCollectionView.delegate = self
+        portfolioCollectionView.dataSource = self
+        portfolioCollectionView.register(RegisterPortfolioImageCell.self, forCellWithReuseIdentifier: portfolioCellIdentifier.images.rawValue)
+        portfolioCollectionView.register(RegisterAddPhotosCollectionViewCell.self, forCellWithReuseIdentifier: portfolioCellIdentifier.addButton.rawValue)
+        
+        completeEditButton.layer.cornerRadius = view.bounds.width/18
+    }
+}
 
+    // MARK: - PHPickerView delegate
+extension ArtistEditPortfoiloViewController: PHPickerViewControllerDelegate {
+    func picker(_ picker: PHPickerViewController, didFinishPicking results: [PHPickerResult]) {
+        picker.dismiss(animated: true)
+        
+        let photoItems = results
+            .map { $0.itemProvider }
+            .filter { $0.canLoadObject(ofClass: UIImage.self) }
+        let dispatchGroup = DispatchGroup()
+        var temporaryImages = [UIImage]()
+        var indexNumber: Int = 0
+        
+        for photoItem in photoItems {
+            indexNumber += 1
+            dispatchGroup.enter()
+            photoItem.loadObject(ofClass: UIImage.self) { photos, error in
+                if let image = photos as? UIImage {
+                    guard let compressedImage = image.jpegData(compressionQuality: 0.0) else { return }
+                    if let jpegPhoto = UIImage(data: compressedImage) {
+                        temporaryImages.append(jpegPhoto)
+                    }
+                }
+                if let error = error {
+                    print(error)
+                }
+                dispatchGroup.leave()
+            }
+        }
+        dispatchGroup.notify(queue: .main) {
+            if (!temporaryImages.isEmpty) {
+                self.portfolioPhotosFetched = temporaryImages
+                self.portfolioCollectionView.reloadData()
+            }
+            self.enableButton()
+        }
+    }
+}
+
+    // MARK: - UICollectionView datasource
+extension ArtistEditPortfoiloViewController: UICollectionViewDataSource {
+    func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
+        return portfolioPhotosFetched.count + 1
+    }
+    
+    func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
+        if indexPath.item < portfolioPhotosFetched.count {
+            guard let cell = collectionView.dequeueReusableCell(withReuseIdentifier: portfolioCellIdentifier.images.rawValue, for: indexPath) as? RegisterPortfolioImageCell else { return UICollectionViewCell()}
+            // MARK: First item of photos becomes the main Photo
+            if indexPath.item == 0 {
+                cell.photoImage.image = self.portfolioPhotosFetched[indexPath.item]
+                cell.mainPhotoMarkLabel.isHidden = false
+                cell.photoImage.layer.borderWidth = 4
+                return cell
+            }
+            cell.photoImage.image = self.portfolioPhotosFetched[indexPath.item]
+            cell.mainPhotoMarkLabel.isHidden = true
+            cell.photoImage.layer.borderWidth = 0
+            return cell
+        } else {
+            guard let cell = collectionView.dequeueReusableCell(withReuseIdentifier: portfolioCellIdentifier.addButton.rawValue, for: indexPath) as? RegisterAddPhotosCollectionViewCell else { return UICollectionViewCell()}
+            if portfolioPhotosFetched.count != 0 {
+                return cell
+            }
+            return cell
+        }
+    }
+}
+
+    // MARK: - UICollectionView delegate
+extension ArtistEditPortfoiloViewController: UICollectionViewDelegate {
+    func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
+        if indexPath.item == portfolioPhotosFetched.count {
+            self.present(portfolioPicker, animated: true)
+        } else {
+            // MARK: Selected Image moves to top of the array
+            let selectedCellIndex = indexPath.item
+            let selectedPhoto = self.portfolioPhotosFetched[selectedCellIndex]
+            self.portfolioPhotosFetched.remove(at: selectedCellIndex)
+            self.portfolioPhotosFetched.insert(selectedPhoto, at: 0)
+            self.portfolioCollectionView.reloadData()
+        }
+    }
+}
+
+extension ArtistEditPortfoiloViewController {
+    private func customBackButton() {
+        let backTapped = UITapGestureRecognizer(target: self, action: #selector(backButtonTapped))
+        customNavigationBarView.customBackButton.addGestureRecognizer(backTapped)
+    }
+    
+    private func completeButton() {
+        let completeTapped = UITapGestureRecognizer(target: self, action: #selector(completeButtonTapped))
+        completeEditButton.addGestureRecognizer(completeTapped)
+    }
+    
+    @objc func backButtonTapped() {
+        self.navigationController?.popViewController(animated: true)
+    }
+    
+    @objc func completeButtonTapped() {
+        self.delegate?.photoSelected(photos: self.portfolioPhotosFetched)
+        self.navigationController?.popViewController(animated: true)
+    }
+    
+    private func enableButton() {
+        if !portfolioPhotosFetched.isEmpty {
+            completeEditButton.isEnabled = true
+            completeEditButton.backgroundColor = .mainPink
+        } else {
+            completeEditButton.isEnabled = false
+            completeEditButton.backgroundColor = .systemGray2.withAlphaComponent(0.6)
+        }
+    }
+    
+    private func resetData() {
+        portfolioPhotosFetched = []
+        portfolioCollectionView.reloadData()
+        guideLabel.isHidden = true
+    }
+}
+
+// MARK: - RegisterPortfolio custom delegate protocol
+protocol EditPortfolioDelegate: AnyObject {
+    func photoSelected(photos imagesPicked: [UIImage])
 }

--- a/Flicker/Screens/ArtistEdit/ViewControllers/ArtistEditRegionsViewController.swift
+++ b/Flicker/Screens/ArtistEdit/ViewControllers/ArtistEditRegionsViewController.swift
@@ -16,7 +16,6 @@ final class ArtistEditRegionsViewController: UIViewController {
     weak var delegate: EditRegionsDelegate?
     
     // MARK: - data sets to post to the server
-    // TODO: - deleate 만들어서 ArtistRegisterViewController 에 연결해야한다.
     var currentRegion: [String] = []
     var selectedRegion: [String] = []
 
@@ -166,17 +165,6 @@ final class ArtistEditRegionsViewController: UIViewController {
         
         completeEditButton.layer.cornerRadius = view.bounds.width/18
     }
-    
-    private func enableButton() {
-        switch selectedRegion.count {
-        case 0:
-            completeEditButton.isEnabled = false
-            completeEditButton.backgroundColor = .systemGray2.withAlphaComponent(0.6)
-        default :
-            completeEditButton.isEnabled = true
-            completeEditButton.backgroundColor = .mainPink
-        }
-    }
 }
 
     // MARK: - collectionView datasource
@@ -280,6 +268,7 @@ extension ArtistEditRegionsViewController: UICollectionViewDelegate, UICollectio
     }
 }
 
+    // MARK: - action functions
 extension ArtistEditRegionsViewController {
     private func customBackButton() {
         let backTapped = UITapGestureRecognizer(target: self, action: #selector(backButtonTapped))
@@ -301,9 +290,21 @@ extension ArtistEditRegionsViewController {
         }
         self.navigationController?.popViewController(animated: true)
     }
+    
+    // MARK: enable disabled button under the condtion
+    private func enableButton() {
+        switch selectedRegion.count {
+        case 0:
+            completeEditButton.isEnabled = false
+            completeEditButton.backgroundColor = .systemGray2.withAlphaComponent(0.6)
+        default :
+            completeEditButton.isEnabled = true
+            completeEditButton.backgroundColor = .mainPink
+        }
+    }
 }
 
-    // MARK: - RegisterRegion custom delegate protocol
+    // MARK: - Edit Region custom delegate protocol
 protocol EditRegionsDelegate: AnyObject {
     func regionSelected(regions regionDatas: [String])
 }

--- a/Flicker/Screens/ArtistEdit/ViewControllers/ArtistEditTagsViewController.swift
+++ b/Flicker/Screens/ArtistEdit/ViewControllers/ArtistEditTagsViewController.swift
@@ -99,7 +99,6 @@ final class ArtistEditTagsViewController: UIViewController {
     }
     
     // MARK: - keyboard automatically pop
-    
     override func touchesBegan(_ touches: Set<UITouch>, with event: UIEvent?) {
         self.view.endEditing(true)
     }
@@ -201,6 +200,7 @@ extension ArtistEditTagsViewController: UITextFieldDelegate {
     }
 }
 
+    // MARK: - action functions
 extension ArtistEditTagsViewController {
     private func customBackButton() {
         let backTapped = UITapGestureRecognizer(target: self, action: #selector(backButtonTapped))
@@ -230,10 +230,12 @@ extension ArtistEditTagsViewController {
         }
     }
     
+    // MARK: joins seperated Strings into a String
     private func joinStrings(array: [String]) -> String {
         return array.joinString(separator: "#")
     }
     
+    // MARK: filters tags
     private func conceptTextTagDescribed(tagLabel: String) {
         let editedStringArray = tagStringConvert(label: tagLabel)
         if editedStringArray.count > 4 {
@@ -247,11 +249,13 @@ extension ArtistEditTagsViewController {
         }
     }
     
+    // MARK: seperates a single merged String
     private func tagStringConvert(label: String) -> [String] {
         let array = label.components(separatedBy: "#").filter{ $0 != ""}
         return array
     }
     
+    // MARK: enable disabled button under the condtion
     private func enableButton() {
         guard let tagText = conceptTagTextField.text else { return }
         if !tagText.isEmpty {
@@ -264,7 +268,7 @@ extension ArtistEditTagsViewController {
     }
 }
 
-// MARK: - RegisterConceptTagDelegate custom delegate protocol
+// MARK: - Edit ConceptTags custom delegate protocol
 protocol EditConceptTagDelegate: AnyObject {
     func conceptTagDescribed(tagLabel: [String])
 }

--- a/Flicker/Screens/ArtistEdit/ViewControllers/ArtistEditViewController.swift
+++ b/Flicker/Screens/ArtistEdit/ViewControllers/ArtistEditViewController.swift
@@ -29,10 +29,11 @@ class ArtistEditViewController: UIViewController {
     // MARK: observer to check whether the async tasks are done
     private var temporaryStrings: [String] = [] {
         didSet {
-            if self.temporaryStrings.count == self.copiedItems.portfolioUrls.count {
+            if self.temporaryStrings.count == self.copiedItems.portfolioImages.count {
                 Task {
                     self.copiedItems.portfolioUrls = self.temporaryStrings
                     await self.dataFirebase.updateArtistInformation(copiedItems)
+                    print("Updated")
                     self.hideLoadingView()
                     self.navigationController?.pushViewController(TabbarViewController(), animated: true)
                 }
@@ -209,10 +210,11 @@ extension ArtistEditViewController {
     private func recheckAlert() {
         let recheckAlert = UIAlertController(title: "수정이 끝나셨나요?", message: "", preferredStyle: .actionSheet)
         let confirm = UIAlertAction(title: "확인", style: .default) { _ in
-            // MARK: 먼저 url 을 통해 서버에 저장된 image를 지우게 만들어야 함
-            for (indexNum, _) in self.copiedItems.portfolioUrls.enumerated() {
+            // MARK: 먼저 url 을 통해 서버에 저장된 image를 지우게 만들어야 함 ✅
+            let numberOfUrls = self.copiedItems.portfolioUrls.count
+            for indexNumber in 0..<numberOfUrls {
                 Task {
-                    await self.dataFirebase.removeImages(urlCount: indexNum)
+                    await self.dataFirebase.removeImages(urlCount: indexNumber)
                 }
             }
             
@@ -221,10 +223,9 @@ extension ArtistEditViewController {
                 Task {
                     async let urlString = self.dataFirebase.uploadImage(photo: photo, indexNum: indexNum)
                     await self.temporaryStrings.append(urlString)
-                    print("Artist is \(self.temporaryStrings)")
                 }
             }
-            
+            self.copiedItems.portfolioUrls.removeAll()
             self.openLoadingView()
         }
         

--- a/Flicker/Screens/ArtistEdit/ViewControllers/ArtistEditViewController.swift
+++ b/Flicker/Screens/ArtistEdit/ViewControllers/ArtistEditViewController.swift
@@ -26,10 +26,10 @@ class ArtistEditViewController: UIViewController {
     private var originalEditData: EditData = EditData(regions: [], camera: "", lens: "", tags: [], detailDescription: "", portfolioImages: [], portfolioUrls: [])
     private var copiedItems: EditData = EditData(regions: [], camera: "", lens: "", tags: [], detailDescription: "", portfolioImages: [], portfolioUrls: [])
     
-    // TODO: main 화면에서 받아온 캐싱된 데이터를 그대로 들고온 dataA 와 그 dataA 와 비교하기 위한 복제된 데이터 dataB 가 있다. 이걸 받아오는 작업이 필요하다. 해당 데이터들은 가데이터들이다.
-    private lazy var dataA = EditData(regions: ["마포구",  "강동구"].sorted(), camera: "소니 a7", lens: "짜이즈 55mm f1.8", tags: ["인물사진", "색감장인", "소니장인"], detailDescription: "뇸뇸뇸뇸자기소개", portfolioImages: [], portfolioUrls: [])
+    // TODO: main 화면에서 받아온 캐싱된 데이터를 그대로 들고온 originalEditData 와 그 originalEditData 와 비교하기 위한 복제된 데이터 copiedItems 가 있다. 이걸 받아오는 작업이 필요하다. 해당 데이터들은 가데이터들이다.
+//    private lazy var originalEditData = EditData(regions: ["마포구",  "강동구"].sorted(), camera: "소니 a7", lens: "짜이즈 55mm f1.8", tags: ["인물사진", "색감장인", "소니장인"], detailDescription: "뇸뇸뇸뇸자기소개", portfolioImages: [], portfolioUrls: [])
     
-    private lazy var dataB = EditData(regions: ["마포구",  "강동구"].sorted(), camera: "소니 a7", lens: "짜이즈 55mm f1.8", tags: ["인물사진", "색감장인", "소니장인"], detailDescription: "뇸뇸뇸뇸자기소개", portfolioImages: [], portfolioUrls: [])
+//    private lazy var copiedItems = EditData(regions: ["마포구",  "강동구"].sorted(), camera: "소니 a7", lens: "짜이즈 55mm f1.8", tags: ["인물사진", "색감장인", "소니장인"], detailDescription: "뇸뇸뇸뇸자기소개", portfolioImages: [], portfolioUrls: [])
     
     private let editItemsArray: [String] = ["지역 수정", "장비 수정", "태그 수정", "자기 소개 수정", "포트폴리오 수정"]
     
@@ -76,7 +76,7 @@ class ArtistEditViewController: UIViewController {
 
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
-        print(dataB)
+        print(copiedItems)
         self.editItemsTableView.reloadData()
         navigationController?.setNavigationBarHidden(true, animated: false)
         self.tabBarController?.tabBar.isHidden = true
@@ -150,7 +150,7 @@ class ArtistEditViewController: UIViewController {
 
 extension ArtistEditViewController {
     @objc func resetEditTapped() {
-        self.dataB = self.dataA
+        self.copiedItems = self.originalEditData
         UIView.animate(withDuration: 0.2, delay: 0.0,options: [.allowUserInteraction, .curveEaseInOut]) {
             self.resetEditButton.transform = CGAffineTransform(scaleX: 0.8, y: 0.8)
         }
@@ -159,7 +159,7 @@ extension ArtistEditViewController {
             self.resetEditButton.transform = CGAffineTransform(scaleX: 1, y: 1)
         }
         self.editItemsTableView.reloadData()
-        print(self.dataB)
+        print(self.copiedItems)
     }
     
     @objc func completeEditTapped() {
@@ -196,7 +196,7 @@ extension ArtistEditViewController: UITableViewDataSource, UITableViewDelegate {
         
         switch indexPath.row {
         case 0:
-            let isEdited = self.dataA.regions != self.dataB.regions
+            let isEdited = self.originalEditData.regions != self.copiedItems.regions
             cell.cellImage.image = UIImage(systemName: editItemsImageArray[indexPath.row], withConfiguration: imageWeight)
             cell.cellTextLabel.text = editItemsArray[indexPath.row]
             if isEdited {
@@ -207,8 +207,8 @@ extension ArtistEditViewController: UITableViewDataSource, UITableViewDelegate {
             
             return cell
         case 1:
-            let isEditedBody = self.dataA.camera != self.dataB.camera
-            let isEditedLens = self.dataA.lens != self.dataB.lens
+            let isEditedBody = self.originalEditData.camera != self.copiedItems.camera
+            let isEditedLens = self.originalEditData.lens != self.copiedItems.lens
             cell.cellImage.image = UIImage(systemName: editItemsImageArray[indexPath.row], withConfiguration: imageWeight)
             cell.cellTextLabel.text = editItemsArray[indexPath.row]
             if isEditedBody || isEditedLens {
@@ -218,7 +218,7 @@ extension ArtistEditViewController: UITableViewDataSource, UITableViewDelegate {
             }
             return cell
         case 2:
-            let isEdited = self.dataA.tags != self.dataB.tags
+            let isEdited = self.originalEditData.tags != self.copiedItems.tags
             cell.cellImage.image = UIImage(systemName: editItemsImageArray[indexPath.row], withConfiguration: imageWeight)
             cell.cellTextLabel.text = editItemsArray[indexPath.row]
             if isEdited {
@@ -229,7 +229,7 @@ extension ArtistEditViewController: UITableViewDataSource, UITableViewDelegate {
             
             return cell
         case 3:
-            let isEdited = self.dataA.detailDescription != self.dataB.detailDescription
+            let isEdited = self.originalEditData.detailDescription != self.copiedItems.detailDescription
             cell.cellImage.image = UIImage(systemName: editItemsImageArray[indexPath.row], withConfiguration: imageWeight)
             cell.cellTextLabel.text = editItemsArray[indexPath.row]
             if isEdited {
@@ -240,7 +240,7 @@ extension ArtistEditViewController: UITableViewDataSource, UITableViewDelegate {
             
             return cell
         case 4:
-            let isEdited = self.dataA.portfolioImages != self.dataB.portfolioImages
+            let isEdited = self.originalEditData.portfolioImages != self.copiedItems.portfolioImages
             cell.cellImage.image = UIImage(systemName: editItemsImageArray[indexPath.row], withConfiguration: imageWeight)
             cell.cellTextLabel.text = editItemsArray[indexPath.row]
             if isEdited {
@@ -260,23 +260,23 @@ extension ArtistEditViewController: UITableViewDataSource, UITableViewDelegate {
         switch indexPath.row {
         case 0:
             let vc = editRegionsViewContrller.then {
-                $0.currentRegion = self.dataB.regions
+                $0.currentRegion = self.copiedItems.regions
             }
             navigationController?.pushViewController(vc, animated: true)
         case 1:
             let vc = editGearsViewController.then {
-                $0.currentLens = self.dataB.lens
-                $0.currentBody = self.dataB.camera
+                $0.currentLens = self.copiedItems.lens
+                $0.currentBody = self.copiedItems.camera
             }
             navigationController?.pushViewController(vc, animated: true)
         case 2:
             let vc = editTagsViewController.then {
-                $0.currentTags = self.dataB.tags
+                $0.currentTags = self.copiedItems.tags
             }
             navigationController?.pushViewController(vc, animated: true)
         case 3:
             let vc = editDescriptionViewController.then {
-                $0.currentInfo = self.dataB.detailDescription
+                $0.currentInfo = self.copiedItems.detailDescription
             }
             navigationController?.pushViewController(vc, animated: true)
         case 4:
@@ -291,21 +291,21 @@ extension ArtistEditViewController: UITableViewDataSource, UITableViewDelegate {
 
 extension ArtistEditViewController: EditRegionsDelegate, EditGearsDelegate, EditConceptTagDelegate, EditTextInfoDelegate, EditPortfolioDelegate {
     func photoSelected(photos imagesPicked: [UIImage]) {
-        self.dataB.portfolioImages = imagesPicked
+        self.copiedItems.portfolioImages = imagesPicked
     }
     func textViewDescribed(textView textDescribed: String) {
-        self.dataB.detailDescription = textDescribed
+        self.copiedItems.detailDescription = textDescribed
     }
     func conceptTagDescribed(tagLabel: [String]) {
-        self.dataB.tags = tagLabel
+        self.copiedItems.tags = tagLabel
     }
     func cameraBodySelected(cameraBody bodyName: String) {
-        self.dataB.camera = bodyName
+        self.copiedItems.camera = bodyName
     }
     func cameraLensSelected(cameraLens lensName: String) {
-        self.dataB.lens = lensName
+        self.copiedItems.lens = lensName
     }
     func regionSelected(regions regionDatas: [String]) {
-        self.dataB.regions = regionDatas.sorted()
+        self.copiedItems.regions = regionDatas.sorted()
     }
 }

--- a/Flicker/Screens/ArtistEdit/ViewControllers/ArtistEditViewController.swift
+++ b/Flicker/Screens/ArtistEdit/ViewControllers/ArtistEditViewController.swift
@@ -16,14 +16,15 @@ struct EditData {
     var tags: [String]
     var detailDescription: String
     var portfolioImages: [UIImage]
+    var portfolioUrls: [String]
 }
 
 class ArtistEditViewController: UIViewController {
     
     // TODO: main 화면에서 받아온 캐싱된 데이터를 그대로 들고온 dataA 와 그 dataA 와 비교하기 위한 복제된 데이터 dataB 가 있다. 이걸 받아오는 작업이 필요하다. 해당 데이터들은 가데이터들이다.
-    private lazy var dataA = EditData(regions: ["마포구",  "강동구"].sorted(), camera: "소니 a7", lens: "짜이즈 55mm f1.8", tags: ["인물사진", "색감장인", "소니장인"], detailDescription: "뇸뇸뇸뇸자기소개", portfolioImages: [exImage])
+    private lazy var dataA = EditData(regions: ["마포구",  "강동구"].sorted(), camera: "소니 a7", lens: "짜이즈 55mm f1.8", tags: ["인물사진", "색감장인", "소니장인"], detailDescription: "뇸뇸뇸뇸자기소개", portfolioImages: [exImage], portfolioUrls: [])
     
-    private lazy var dataB = EditData(regions: ["마포구",  "강동구"].sorted(), camera: "소니 a7", lens: "짜이즈 55mm f1.8", tags: ["인물사진", "색감장인", "소니장인"], detailDescription: "뇸뇸뇸뇸자기소개", portfolioImages: [exImage])
+    private lazy var dataB = EditData(regions: ["마포구",  "강동구"].sorted(), camera: "소니 a7", lens: "짜이즈 55mm f1.8", tags: ["인물사진", "색감장인", "소니장인"], detailDescription: "뇸뇸뇸뇸자기소개", portfolioImages: [exImage], portfolioUrls: [])
     
     let exImage = UIImage(named: "RegisterEnd") ?? UIImage()
     
@@ -72,6 +73,7 @@ class ArtistEditViewController: UIViewController {
 
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
+        print(dataB)
         self.editItemsTableView.reloadData()
         navigationController?.setNavigationBarHidden(true, animated: false)
         self.tabBarController?.tabBar.isHidden = true
@@ -117,6 +119,7 @@ class ArtistEditViewController: UIViewController {
         editGearsViewController.delegate = self
         editTagsViewController.delegate = self
         editDescriptionViewController.delegate = self
+        editPortfoiloViewController.delegate = self
         
         editItemsTableView.delegate = self
         editItemsTableView.dataSource = self
@@ -253,7 +256,11 @@ extension ArtistEditViewController: UITableViewDataSource, UITableViewDelegate {
     }
 }
 
-extension ArtistEditViewController: EditRegionsDelegate, EditGearsDelegate, EditConceptTagDelegate, EditTextInfoDelegate {
+extension ArtistEditViewController: EditRegionsDelegate, EditGearsDelegate, EditConceptTagDelegate, EditTextInfoDelegate, EditPortfolioDelegate {
+    func photoSelected(photos imagesPicked: [UIImage]) {
+        self.dataB.portfolioImages = imagesPicked
+    }
+    
     func textViewDescribed(textView textDescribed: String) {
         self.dataB.detailDescription = textDescribed
     }

--- a/Flicker/Screens/ArtistRegister/ViewControllers/ArtistRegisterViewController.swift
+++ b/Flicker/Screens/ArtistRegister/ViewControllers/ArtistRegisterViewController.swift
@@ -256,12 +256,7 @@ extension ArtistRegisterViewController {
         recheckAlert.addAction(cancel)
         present(recheckAlert, animated: true, completion: nil)
     }
-    
-    // MARK: uploading Data func (Not UIImages)
-    private func sequenceUploadingDatas() async {
-        await self.dataFirebase.storeArtistInformation(self.dataSourceToServer)
-    }
-    
+
     // MARK: changing loading view status action
     private func openLoadingView() {
         self.loadingView.isHidden = false

--- a/Flicker/Screens/ArtistRegister/ViewControllers/ArtistRegisterViewController.swift
+++ b/Flicker/Screens/ArtistRegister/ViewControllers/ArtistRegisterViewController.swift
@@ -245,6 +245,7 @@ extension ArtistRegisterViewController {
                     print("Artist is \(self.temporaryStrings)")
                 }
             }
+            UserDefaults.standard.set(true, forKey: "isArtist")
             // MARK: Intentional delay for uploading the photos
             self.openLoadingView()
         }

--- a/Flicker/Screens/ArtistRegister/ViewControllers/ArtistRegisterViewController.swift
+++ b/Flicker/Screens/ArtistRegister/ViewControllers/ArtistRegisterViewController.swift
@@ -16,8 +16,8 @@ import Then
 final class ArtistRegisterViewController: UIViewController {
     
     // MARK: - datas collected to post to the server
-    let dataFirebase = FirebaseManager()
-    let userDefaultInfo = UserDefaults.standard.getObjects(forKeys: ["userEmail", "userName", "userProfileImageUrl", "userToken", "userId"])
+    private let dataFirebase = FirebaseManager()
+    private let userDefaultInfo = UserDefaults.standard.getObjects(forKeys: ["userEmail", "userName", "userProfileImageUrl", "userToken", "userId"])
     
     private lazy var dataSourceToServer = Artist(regions: [], camera: "", lens: "", tags: [], detailDescription: "", portfolioImageUrls: [], userInfo: userDefaultInfo)
     

--- a/Flicker/Screens/ArtistRegister/ViewControllers/RegisterConceptTagViewController.swift
+++ b/Flicker/Screens/ArtistRegister/ViewControllers/RegisterConceptTagViewController.swift
@@ -22,6 +22,7 @@ final class RegisterConceptTagViewController: UIViewController {
     }
     
     private let subTitleLabel = UILabel().then {
+        $0.numberOfLines = 2
         $0.font = UIFont.preferredFont(forTextStyle: .title3, weight: .bold)
         $0.text = "작가님의 대표 컨셉들을 태그로 남겨주세요!"
     }

--- a/Flicker/Screens/ArtistRegister/ViewControllers/RegisterConfirmViewController.swift
+++ b/Flicker/Screens/ArtistRegister/ViewControllers/RegisterConfirmViewController.swift
@@ -109,6 +109,6 @@ extension RegisterConfirmViewController {
     
     // Tabview 로 넘어가야함! 돌려놔!
     @objc func moveNextTapped() {
-        navigationController?.pushViewController(ArtistEditViewController(), animated: true)
+        navigationController?.pushViewController(TabbarViewController(), animated: true)
     }
 }

--- a/Flicker/Screens/ArtistRegister/ViewControllers/RegisterConfirmViewController.swift
+++ b/Flicker/Screens/ArtistRegister/ViewControllers/RegisterConfirmViewController.swift
@@ -107,7 +107,8 @@ extension RegisterConfirmViewController {
         dynamicNextButton.addGestureRecognizer(buttonTapped)
     }
     
+    // Tabview 로 넘어가야함! 돌려놔!
     @objc func moveNextTapped() {
-        navigationController?.pushViewController(TabbarViewController(), animated: true)
+        navigationController?.pushViewController(ArtistEditViewController(), animated: true)
     }
 }

--- a/Flicker/Screens/ArtistRegister/ViewControllers/RegisterConfirmViewController.swift
+++ b/Flicker/Screens/ArtistRegister/ViewControllers/RegisterConfirmViewController.swift
@@ -107,7 +107,7 @@ extension RegisterConfirmViewController {
         dynamicNextButton.addGestureRecognizer(buttonTapped)
     }
     
-    // Tabview 로 넘어가야함! 돌려놔!
+    // popToRoot 하면?
     @objc func moveNextTapped() {
         navigationController?.pushViewController(TabbarViewController(), animated: true)
     }

--- a/Flicker/Screens/Profile/Cell/ProfileEnumeration.swift
+++ b/Flicker/Screens/Profile/Cell/ProfileEnumeration.swift
@@ -26,7 +26,7 @@ enum ProfileSection: Int, CaseIterable {
     case signOut
     
     func sectionOptions(isArtist: Bool) -> [String] {
-        let category = isArtist ? "작가설정" : "작가등록"
+        let category = isArtist ? "작가 수정" : "작가 등록"
         
         switch self {
         case .settings:

--- a/Flicker/Screens/Profile/ProfileViewController.swift
+++ b/Flicker/Screens/Profile/ProfileViewController.swift
@@ -104,6 +104,10 @@ final class ProfileViewController: EmailViewController {
     private func goToArtistRegistration() {
         transition(RegisterWelcomeViewController(), transitionStyle: .push)
     }
+    
+    private func goToEditArtist() {
+        transition(ArtistEditViewController(), transitionStyle: .push)
+    }
 
     private func goToCustomerInquiry() {
         sendReportMail(userName: userName, reportType: .askSomething)
@@ -178,7 +182,7 @@ extension ProfileViewController: UITableViewDelegate {
             case 0:
                 setNotification()
             case 1:
-                isArtist ? print("이 영역에 작가 프로필을 수정 하는 뷰를 만들어 넣어야 합니다.") : goToArtistRegistration()
+                isArtist ? goToEditArtist() : goToArtistRegistration()
             case 2:
                 goToCustomerInquiry()
             default:

--- a/Flicker/Screens/Profile/ProfileViewController.swift
+++ b/Flicker/Screens/Profile/ProfileViewController.swift
@@ -11,8 +11,8 @@ import FirebaseAuth
 
 final class ProfileViewController: EmailViewController {
     // MARK: - Properties: User Data
+    private let isArtist: Bool = UserDefaults.standard.bool(forKey: "isArtist")
     private let userName: String? = nil
-    private var isArtist: Bool = false
     private let defaults = UserDefaults.standard
     private let profileSettingView = ProfileSettingViewController()
     // MARK: - Properties: UITable layout


### PR DESCRIPTION
## 🌁 배경
- 작가 정보 중 포트폴리오 수정 뷰를 따로 뺀건, 생각보다 볼륨이 크기 때문이었습니다.
- 네트워크 관련된 함수와 모델을 따로 구현해야 했으며, 오류가 생기면 유저의 UX를 크게 저해하기 때문에 꼼꼼한 설계가 필요했습니다.

## 👩‍💻 작업 내용 (Content)
- Artist 모델을 바로 사용하지 않고, edit 에 필요한 부분을 따로 모델로 만들었습니다.
- firebase 에서 데이터를 주고 받는 함수들을 만들었습니다.
- edit 하면, storage 에 올라가 있는 사진은 모두 삭제되며, 새롭게 만들어진 포트폴리오가 업로드 됩니다.
- 이미지를 수정하지 않았을 때의 상황도 분기처리를 해서 문제가 없습니다.
- 로딩뷰도 당연히 만들었습니다.
- 새로 만든 모든 뷰에 이해를 돕기 위한 주석을 처리했습니다. 유지보수에 용이해질 것이라 생각합니다.

## 📱 스크린샷

https://user-images.githubusercontent.com/89404664/204521262-f17c2999-85bf-4035-ab21-4f41754078e7.mp4



## ✅ 테스트방법
작가가 등록 후, 프로필에서 작가 수정을 누르면 됩니다.

## 📣 PR & Issues
- Closed #102 
- Closed #164 

## 📬 참고문서, 레퍼런스

