### PR TITLE
💄  회원가입 플로우에 뒤로가기 버튼 추가 및 스와이프 제스쳐 기능 추가

### DIFF
--- a/Flicker/Global/Base/BaseViewController.swift
+++ b/Flicker/Global/Base/BaseViewController.swift
@@ -85,7 +85,6 @@ class BaseViewController: UIViewController {
     }
 
     func setupInteractivePopGestureRecognizer() {
-        self.navigationController?.interactivePopGestureRecognizer?.isEnabled = true
         self.navigationController?.interactivePopGestureRecognizer?.delegate = self
     }
 

--- a/Flicker/Global/Base/BaseViewController.swift
+++ b/Flicker/Global/Base/BaseViewController.swift
@@ -84,14 +84,15 @@ class BaseViewController: UIViewController {
         navigationItem.leftBarButtonItem = backButton
     }
 
+    func setupInteractivePopGestureRecognizer() {
+        self.navigationController?.interactivePopGestureRecognizer?.isEnabled = true
+        self.navigationController?.interactivePopGestureRecognizer?.delegate = self
+    }
+
     // MARK: - private func
     
     @objc func didTapBackButton() {
         self.navigationController?.popViewController(animated: true)
-    }
-    
-    private func setupInteractivePopGestureRecognizer() {
-        self.navigationController?.interactivePopGestureRecognizer?.delegate = self
     }
     
     @objc func keyboardWillShow(notification: NSNotification) {

--- a/Flicker/Screens/SignUp/LoginProfileViewController.swift
+++ b/Flicker/Screens/SignUp/LoginProfileViewController.swift
@@ -41,6 +41,10 @@ final class LoginProfileViewController: BaseViewController {
     }
 
     // MARK: -LoginProfileViewUI
+    private lazy var backButton = RegisterCustomNavigationView().customBackButton.then {
+        $0.addTarget(self, action: #selector(didTapBackButton), for: .touchUpInside)
+    }
+    
     private lazy var imagePicker = UIImagePickerController().then {
         $0.sourceType = .photoLibrary
         $0.allowsEditing = true
@@ -130,7 +134,7 @@ final class LoginProfileViewController: BaseViewController {
         nickNameTextFieldClearButton.isHidden = true
         nickNameCountLabel.isHidden = true
 
-        view.addSubviews(profileImageView, cameraImage ,profileLabelFirst, profileLabelSecond, nickNameLabel, isArtistLabel, afterJoinLabel, nickNameField, nickNameCountLabel ,artistTrueButton, artistFalseButton, signUpButton, nickNameTextFieldClearButton, nickNameDivider)
+        view.addSubviews(backButton, profileImageView, cameraImage ,profileLabelFirst, profileLabelSecond, nickNameLabel, isArtistLabel, afterJoinLabel, nickNameField, nickNameCountLabel ,artistTrueButton, artistFalseButton, signUpButton, nickNameTextFieldClearButton, nickNameDivider)
 
         view.addSubviews(loadingView, spinnerView,loadingLabel)
 
@@ -139,6 +143,11 @@ final class LoginProfileViewController: BaseViewController {
         artistFalseButton.addTarget(self, action: #selector(didTapArtistFalseButton), for: .touchUpInside)
         signUpButton.addTarget(self, action: #selector(didTapSignUpButton), for: .touchUpInside)
         nickNameTextFieldClearButton.addTarget(self, action: #selector(didTapClearButton), for: .touchUpInside)
+
+        backButton.snp.makeConstraints {
+            $0.top.equalTo(view.safeAreaLayoutGuide.snp.top).offset(20)
+            $0.leading.equalToSuperview().inset(15)
+        }
 
         profileImageView.snp.makeConstraints {
             $0.top.equalTo(view.safeAreaLayoutGuide.snp.top).offset(50)
@@ -231,6 +240,11 @@ final class LoginProfileViewController: BaseViewController {
             $0.centerX.equalToSuperview()
             $0.centerY.equalTo(self.spinnerView.snp.bottom).offset(35)
         }
+    }
+    
+    override func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
+        super.setupInteractivePopGestureRecognizer()
     }
 
     @objc private func selectButtonTouched(_ recognizer: UITapGestureRecognizer) {

--- a/Flicker/Screens/SignUp/SignUpViewController.swift
+++ b/Flicker/Screens/SignUp/SignUpViewController.swift
@@ -14,10 +14,7 @@ final class SignUpViewController: BaseViewController {
 
     private let didTapSignUpEmail = true
 
-    private lazy var backButton = UIButton().then {
-        $0.setPreferredSymbolConfiguration(.init(pointSize: 27, weight: .bold, scale: .large), forImageIn: .normal)
-        $0.tintColor = .black
-        $0.setImage(ImageLiteral.btnBack, for: .normal)
+    private lazy var backButton = RegisterCustomNavigationView().customBackButton.then {
         $0.addTarget(self, action: #selector(didTapBackButton), for: .touchUpInside)
     }
 
@@ -174,8 +171,12 @@ final class SignUpViewController: BaseViewController {
 
     override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
-        emailField.becomeFirstResponder()
+        super.setupInteractivePopGestureRecognizer()
     }
+
+//    override func setupInteractivePopGestureRecognizer() {
+//        super.setupInteractivePopGestureRecognizer()
+//    }
 
     @objc private func didTapSignUpButton() {
         let viewController = LoginProfileViewController()

--- a/Flicker/Screens/SignUp/SignUpViewController.swift
+++ b/Flicker/Screens/SignUp/SignUpViewController.swift
@@ -114,7 +114,7 @@ final class SignUpViewController: BaseViewController {
 
         backButton.snp.makeConstraints {
             $0.top.equalTo(view.safeAreaLayoutGuide.snp.top).offset(20)
-            $0.leading.equalToSuperview().inset(20)
+            $0.leading.equalToSuperview().inset(15)
         }
 
         signUpTitleLabel.snp.makeConstraints {

--- a/Flicker/Screens/SignUp/SignUpViewController.swift
+++ b/Flicker/Screens/SignUp/SignUpViewController.swift
@@ -14,8 +14,14 @@ final class SignUpViewController: BaseViewController {
 
     private let didTapSignUpEmail = true
 
-    private let signUpTitleLabel = UILabel().makeBasicLabel(labelText: "반가워요!", textColor: .mainPink, fontStyle: .largeTitle, fontWeight: .bold)
+    private lazy var backButton = UIButton().then {
+        $0.setPreferredSymbolConfiguration(.init(pointSize: 27, weight: .bold, scale: .large), forImageIn: .normal)
+        $0.tintColor = .black
+        $0.setImage(ImageLiteral.btnBack, for: .normal)
+        $0.addTarget(self, action: #selector(didTapBackButton), for: .touchUpInside)
+    }
 
+    private let signUpTitleLabel = UILabel().makeBasicLabel(labelText: "반가워요!", textColor: .mainPink, fontStyle: .largeTitle, fontWeight: .bold)
 
     private let signUpLabel = UILabel().then {
         $0.tintColor = .textSubBlack
@@ -107,10 +113,15 @@ final class SignUpViewController: BaseViewController {
         passwordValidCheckLabel.isHidden = true
         passwordSameCheckLabel.isHidden = true
 
-        view.addSubviews(emailValidCheckLabel ,signUpTitleLabel, signUpLabel, emailField, passwordField, signUpButton, passwordSameCheckField, passwordValidCheckLabel, passwordSameCheckLabel)
+        view.addSubviews(backButton, emailValidCheckLabel,signUpTitleLabel, signUpLabel, emailField, passwordField, signUpButton, passwordSameCheckField, passwordValidCheckLabel, passwordSameCheckLabel)
+
+        backButton.snp.makeConstraints {
+            $0.top.equalTo(view.safeAreaLayoutGuide.snp.top).offset(20)
+            $0.leading.equalToSuperview().inset(20)
+        }
 
         signUpTitleLabel.snp.makeConstraints {
-            $0.top.equalTo(view.safeAreaLayoutGuide.snp.top).offset(40)
+            $0.top.equalTo(view.safeAreaLayoutGuide.snp.top).offset(80)
             $0.leading.equalToSuperview().inset(30)
         }
 


### PR DESCRIPTION
## 🌁 배경
- 앱에 대한 버그를 찾으며 UX에 증가를 위한 과정 중 나온 회원가입 뷰의 추가 기능 입니다.

## 👩‍💻 작업 내용 (Content)
- backButton의 경우 통일성을 위해서 피칸파이의 코드를 선언하여 사용했습니다.

- 스와이프 제스쳐의 경우 baseVC에 이미 버그에 대한 부분까지 코드가 잘 짜여져있는 것을 발견하여, 추가했습니다.
   사용을 원하는 뷰에서는 선언만 해주면 바로 영상과 같이 사용이 가능합니다.

## 📱 스크린샷
- 화면 전환이나 인터렉션이 있는 경우엔 GIF, 정적인 화면이라면 스크린샷을 이용합니다.

https://user-images.githubusercontent.com/81131715/204825390-79d9282f-255b-42ff-9f60-7dd52507fdbb.mp4

## ✅ 테스트방법
- 제스쳐 기능 확인 및 뒤로가기 기능을 확인해주시면 됩니다.

## 📣 PR & Issues
- 현재 작성 중인 Pull Request와 관련된 PR과 Issues가 있다면 나열합니다.
- closed #185 

