### PR TITLE
🐛 지역 태그 10개 넘을시, 처음꺼 삭제

### DIFF
--- a/Flicker/Screens/Region/RegionViewController.swift
+++ b/Flicker/Screens/Region/RegionViewController.swift
@@ -94,7 +94,13 @@ final class RegionViewController: BaseViewController {
         } else {
             selectedRegions = selectedRegions.filter {$0 != "전체"}
             selectedRegions.append(region)
+            
+            if selectedRegions.count > 10 {
+                selectedRegions.removeFirst()
+            }
         }
+        
+        print(selectedRegions)
     }
     
     func removeRegion(region: String) {

--- a/Flicker/Screens/Region/UIComponent/RegionTagListView.swift
+++ b/Flicker/Screens/Region/UIComponent/RegionTagListView.swift
@@ -98,13 +98,10 @@ extension RegionTagListView: UICollectionViewDataSource {
 extension RegionTagListView: UICollectionViewDelegateFlowLayout {
     func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
         parent?.addRegion(region: regionList[indexPath.item])
+        listCollectionView.reloadData()
     }
     
     func collectionView(_ collectionView: UICollectionView, didDeselectItemAt indexPath: IndexPath) {
         parent?.removeRegion(region: regionList[indexPath.item])
-    }
-    
-    func collectionView(_ collectionView: UICollectionView, shouldSelectItemAt indexPath: IndexPath) -> Bool {
-        return regionList.count < 10
     }
 }

--- a/Flicker/Screens/Region/UIComponent/RegionTagListView.swift
+++ b/Flicker/Screens/Region/UIComponent/RegionTagListView.swift
@@ -105,6 +105,6 @@ extension RegionTagListView: UICollectionViewDelegateFlowLayout {
     }
     
     func collectionView(_ collectionView: UICollectionView, shouldSelectItemAt indexPath: IndexPath) -> Bool {
-        return listCollectionView.indexPathsForSelectedItems!.count < 10
+        return regionList.count < 10
     }
 }


### PR DESCRIPTION
## 🌁 배경
- 지역 태그를 10개 이상 선택하면, 앱이 터지는 에러를 수정했습니다.

## 👩‍💻 작업 내용 (Content)
- 파이어베이스 쿼리에서 10개이상을 조회하는 것을 지원하지 않습니다. 따라서 지역 태그 선택을 10개이상 했을 시에, 첫번째선택된 태그를 해제하도록 하였습니다.

## 📱 스크린샷


https://user-images.githubusercontent.com/57849386/206328627-60e4b61a-f2c2-4e84-9c4e-d88abc7d7ab7.mp4



## ✅ 테스트방법
- 태그를 마구마구 눌러보세요,

## 📣 PR & Issues
- closed #195

## 📬 참고문서, 레퍼런스
- 작업을 하면서 참고한 문서 및 레퍼런스를 작성합니다.

