### PR TITLE
🐛 채팅시에 키보드 Hide 범위 수정

### DIFF
--- a/Flicker/Screens/Chat/ChatViewController.swift
+++ b/Flicker/Screens/Chat/ChatViewController.swift
@@ -228,6 +228,7 @@ final class ChatViewController: BaseViewController {
     func hidekeyboardWhenTappedAroundExceptSendView() {
         let tap = UITapGestureRecognizer(target: self, action: #selector(dismissKeyboard))
         tap.cancelsTouchesInView = false
+        view.gestureRecognizers?.removeAll()
         chatTableView.addGestureRecognizer(tap)
     }
 }


### PR DESCRIPTION
## 🌁 배경
- 채팅시에, 전송 버튼을 누를 때 키보드가 닫혀서 채팅이 불편하던 UX를 개선하였습니다.

## 👩‍💻 작업 내용 (Content)
- 터치 시에, 키보드가 사라지는 뷰의 범위를 수정하였습니다.

## 📱 스크린샷
- 화면 전환이나 인터렉션이 있는 경우엔 GIF, 정적인 화면이라면 스크린샷을 이용합니다.

## ✅ 테스트방법
- 디바이스에 설치 후, 채팅기능을 사용해보시면, 개선된 UX를 체감할 수 있습니다.

## 📣 PR & Issues
- closed #196

## 📬 참고문서, 레퍼런스
- 작업을 하면서 참고한 문서 및 레퍼런스를 작성합니다.

