### PR TITLE
💄 작가 포트폴리오 이미지 전체화면 취소 버튼 UI 변경 및 작가디테일뷰 스와이프해서 뒤로가기 추가

### DIFF
--- a/Flicker/Screens/Artist/ArtistTappedViewController.swift
+++ b/Flicker/Screens/Artist/ArtistTappedViewController.swift
@@ -107,9 +107,11 @@ final class ArtistTappedViewController: BaseViewController {
     }
     
     override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
         setupBackButton()
         setupNavigationBar()
         tabBarController?.tabBar.isHidden = true
+        super.setupInteractivePopGestureRecognizer()
         DispatchQueue.main.asyncAfter(deadline: .now() + 0.001) {
             self.showSkeletonView()
         }

--- a/Flicker/Screens/Artist/ImageSliderViewController.swift
+++ b/Flicker/Screens/Artist/ImageSliderViewController.swift
@@ -15,11 +15,10 @@ final class ImageSliderViewController: UIPageViewController {
 
     var subViewControllers: [UIViewController] = []
 
-    private lazy var backButton = BackButton().then {
-        $0.frame.size.width = 30
-        $0.frame.size.height = 30
-        $0.layer.cornerRadius = 15
-        $0.backgroundColor = .white.withAlphaComponent(0.7)
+    private lazy var dismissButton = BackButton().then {
+        let imageConfiguration = UIImage.SymbolConfiguration(pointSize: CGFloat(24), weight: .light)
+        $0.setImage(UIImage(systemName: "x.circle.fill", withConfiguration: imageConfiguration), for: .normal)
+        $0.tintColor = .white
         $0.addTarget(self, action: #selector(didTapCustomBackButton), for: .touchUpInside)
     }
 
@@ -29,11 +28,11 @@ final class ImageSliderViewController: UIPageViewController {
         delegate = self
         setImageSlide()
         setViewControllerFromIndex(index: startingPageIndex)
-        configUI()
+        setNavigationItem()
     }
 
-    private func configUI() {
-        self.navigationItem.leftBarButtonItem = UIBarButtonItem(customView: backButton)
+    private func setNavigationItem() {
+        setupRightNavigationBarItem(with: dismissButton)
         self.navigationItem.hidesBackButton = true
     }
 

--- a/Flicker/Screens/Artist/ImageSliderViewController.swift
+++ b/Flicker/Screens/Artist/ImageSliderViewController.swift
@@ -32,7 +32,7 @@ final class ImageSliderViewController: UIPageViewController {
     }
 
     private func setNavigationItem() {
-        setupRightNavigationBarItem(with: dismissButton)
+        self.navigationItem.rightBarButtonItem = UIBarButtonItem(customView: dismissButton)
         self.navigationItem.hidesBackButton = true
     }
 

--- a/Flicker/Screens/Main/MainViewController.swift
+++ b/Flicker/Screens/Main/MainViewController.swift
@@ -79,6 +79,11 @@ final class MainViewController: BaseViewController {
         super.viewDidLoad()
         loadData()
     }
+
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        navigationController?.isNavigationBarHidden = true
+    }
     
     override func render() {
         view.addSubviews(appTitleLabel, regionTagButton, emptyThumnailView, listCollectionView, emptyThumnailView)


### PR DESCRIPTION
## 👩‍💻 작업 내용 (Content)
1. 전체화면 취소 버튼이 백버튼 모양에서 x 표시로 변경되었습니다.
2. 작가디테일뷰에서 왼쪽 스와이프해서 뒤로가기 기능이 추가되었습니다. 

## 📱 스크린샷
  <img width="200" alt="스크린샷1" src="https://user-images.githubusercontent.com/103009135/206365078-61e950c0-1724-49c0-8071-86d5f255b421.png">
