### PR TITLE
💄 ProfileView의 UI를 수정했습니다.

### DIFF
--- a/Flicker/Screens/SignUp/LoginProfileViewController.swift
+++ b/Flicker/Screens/SignUp/LoginProfileViewController.swift
@@ -52,11 +52,19 @@ final class LoginProfileViewController: BaseViewController {
     }
 
     private lazy var profileImageView = UIImageView().then {
+        $0.layer.borderColor = UIColor.systemGray5.cgColor
+        $0.layer.borderWidth = 2
         $0.backgroundColor = .loginGray
         $0.layer.cornerRadius = 50
+        $0.layer.masksToBounds = true
         $0.clipsToBounds = true
         $0.isUserInteractionEnabled = true
         $0.addGestureRecognizer(UITapGestureRecognizer(target: self, action: #selector(selectButtonTouched)))
+    }
+
+    private let plusImage = UIImageView().then {
+        $0.tintColor = .mainPink
+        $0.image = UIImage(systemName: "plus.circle.fill")
     }
 
     private let cameraImage = UIImageView().then {
@@ -76,8 +84,6 @@ final class LoginProfileViewController: BaseViewController {
 
     private let profileLabelSecond = UILabel().makeBasicLabel(labelText: "프로필 사진은 작가와 모델의 매칭에 도움을 줍니다", textColor: .textSubBlack, fontStyle: .caption1, fontWeight: .medium)
     private let nickNameLabel = UILabel().makeBasicLabel(labelText: "닉네임", textColor: .black, fontStyle: .title3, fontWeight: .bold)
-    private let isArtistLabel = UILabel().makeBasicLabel(labelText: "사진작가로 활동할 예정이신가요?", textColor: .black, fontStyle: .title3, fontWeight: .bold)
-    private let afterJoinLabel = UILabel().makeBasicLabel(labelText: "가입 후 마이프로필에서 작가등록을 하실 수 있어요!", textColor: .textSubBlack, fontStyle: .caption1, fontWeight: .medium)
 
     private lazy var nickNameField = UITextField().then {
         let attributes = [
@@ -103,20 +109,6 @@ final class LoginProfileViewController: BaseViewController {
         $0.tintColor = .textSubBlack
     }
 
-    private let artistTrueButton = UIButton().then {
-        $0.setTitle("네", for: .normal)
-        $0.backgroundColor = .loginGray
-        $0.setTitleColor(.black, for: .normal)
-        $0.layer.cornerRadius = DeviceFrame.screenHeight * 0.012
-    }
-
-    private let artistFalseButton = UIButton().then {
-        $0.setTitle("아니오", for: .normal)
-        $0.backgroundColor = .loginGray
-        $0.setTitleColor(.black, for: .normal)
-        $0.layer.cornerRadius = DeviceFrame.screenHeight * 0.012
-    }
-
     private let signUpButton = UIButton().then {
         $0.backgroundColor = .systemGray2
         $0.setTitleColor(.white, for: .normal)
@@ -134,13 +126,10 @@ final class LoginProfileViewController: BaseViewController {
         nickNameTextFieldClearButton.isHidden = true
         nickNameCountLabel.isHidden = true
 
-        view.addSubviews(backButton, profileImageView, cameraImage ,profileLabelFirst, profileLabelSecond, nickNameLabel, isArtistLabel, afterJoinLabel, nickNameField, nickNameCountLabel ,artistTrueButton, artistFalseButton, signUpButton, nickNameTextFieldClearButton, nickNameDivider)
+        view.addSubviews(backButton, profileImageView, cameraImage, plusImage, profileLabelFirst, profileLabelSecond, nickNameLabel, nickNameField, nickNameCountLabel, signUpButton, nickNameTextFieldClearButton, nickNameDivider)
 
         view.addSubviews(loadingView, spinnerView,loadingLabel)
 
-
-        artistTrueButton.addTarget(self, action: #selector(didTapArtistTrueButton), for: .touchUpInside)
-        artistFalseButton.addTarget(self, action: #selector(didTapArtistFalseButton), for: .touchUpInside)
         signUpButton.addTarget(self, action: #selector(didTapSignUpButton), for: .touchUpInside)
         nickNameTextFieldClearButton.addTarget(self, action: #selector(didTapClearButton), for: .touchUpInside)
 
@@ -150,7 +139,7 @@ final class LoginProfileViewController: BaseViewController {
         }
 
         profileImageView.snp.makeConstraints {
-            $0.top.equalTo(view.safeAreaLayoutGuide.snp.top).offset(50)
+            $0.top.equalTo(view.safeAreaLayoutGuide.snp.top).offset(120)
             $0.centerX.equalToSuperview()
             $0.width.height.equalTo(100)
         }
@@ -159,6 +148,12 @@ final class LoginProfileViewController: BaseViewController {
             $0.center.equalTo(profileImageView.snp.center)
             $0.width.equalTo(50)
             $0.height.equalTo(40)
+        }
+
+        plusImage.snp.makeConstraints {
+            $0.leading.equalTo(profileImageView.snp.trailing).inset(30)
+            $0.top.equalTo(profileImageView.snp.bottom).inset(35)
+            $0.width.height.equalTo(35)
         }
 
         profileLabelFirst.snp.makeConstraints {
@@ -199,28 +194,6 @@ final class LoginProfileViewController: BaseViewController {
             $0.leading.trailing.equalToSuperview().inset(20)
         }
 
-        isArtistLabel.snp.makeConstraints {
-            $0.top.equalTo(nickNameField.snp.bottom).offset(20)
-            $0.leading.trailing.equalToSuperview().inset(20)
-        }
-
-        afterJoinLabel.snp.makeConstraints {
-            $0.top.equalTo(isArtistLabel.snp.bottom).offset(10)
-            $0.leading.trailing.equalToSuperview().inset(20)
-        }
-
-        artistTrueButton.snp.makeConstraints {
-            $0.top.equalTo(afterJoinLabel.snp.bottom).offset(10)
-            $0.leading.equalToSuperview().inset(20)
-            $0.trailing.equalTo(view.snp.centerX).inset(25)
-        }
-
-        artistFalseButton.snp.makeConstraints {
-            $0.top.equalTo(afterJoinLabel.snp.bottom).offset(10)
-            $0.trailing.equalToSuperview().inset(20)
-            $0.leading.equalTo(view.snp.centerX).offset(10)
-        }
-
         signUpButton.snp.makeConstraints {
             $0.bottom.equalTo(view.safeAreaLayoutGuide.snp.bottom).inset(50)
             $0.leading.trailing.equalToSuperview().inset(20)
@@ -245,45 +218,13 @@ final class LoginProfileViewController: BaseViewController {
     override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
         super.setupInteractivePopGestureRecognizer()
+        nickNameField.becomeFirstResponder()
     }
 
     @objc private func selectButtonTouched(_ recognizer: UITapGestureRecognizer) {
         self.present(imagePicker, animated: true)
     }
 
-    @objc private func didTapArtistTrueButton() {
-        artistTrueButton.backgroundColor = .mainPink
-        artistTrueButton.setTitleColor(.white, for: .normal)
-        artistFalseButton.backgroundColor = .loginGray
-        artistFalseButton.setTitleColor(.black, for: .normal)
-
-        if isNickNameWrite && !nickNameField.text!.isEmpty {
-            signUpButton.isEnabled = true
-            signUpButton.backgroundColor = .mainPink
-        } else {
-            signUpButton.isEnabled = false
-            signUpButton.backgroundColor = .systemGray2
-        }
-
-        isTapArtistButton = true
-    }
-
-    @objc private func didTapArtistFalseButton() {
-        artistTrueButton.backgroundColor = .loginGray
-        artistTrueButton.setTitleColor(.black, for: .normal)
-        artistFalseButton.backgroundColor = .mainPink
-        artistFalseButton.setTitleColor(.white, for: .normal)
-
-        if isNickNameWrite && !nickNameField.text!.isEmpty {
-            signUpButton.isEnabled = true
-            signUpButton.backgroundColor = .mainPink
-        } else {
-            signUpButton.isEnabled = false
-            signUpButton.backgroundColor = .systemGray2
-        }
-
-        isTapArtistButton = true
-    }
     //TODO: profileImage가 없을 경우 이미지 값을 SFSymbol에서 받으려고 하는데 그 값조차 옵셔널 값으로 인식함 그래서 일단 강제언래핑 해놓음
     @objc private func didTapSignUpButton() {
         let viewController = TabbarViewController()
@@ -397,6 +338,7 @@ extension LoginProfileViewController: UIImagePickerControllerDelegate, UINavigat
         }
         self.profileImageView.image = newImage
         self.cameraImage.isHidden = true
+        self.plusImage.isHidden = true
         dismiss(animated: true, completion: nil)
     }
 }


### PR DESCRIPTION
## 🌁 배경
- 회원가입 플로우 중 프로필 정보를 입력하는 뷰의 UX에 변경이 필요함을 느껴 이를 수정했습니다.

## 👩‍💻 작업 내용 (Content)
- 프로필 사진의 변경을 요구하는 UX가 부족하다고 생각하여 Plus 이미지를 추가했습니다.
- 작가등록여부를 표시하는 버튼을 삭제했습니다.

## 📱 스크린샷
- 화면 전환이나 인터렉션이 있는 경우엔 GIF, 정적인 화면이라면 스크린샷을 이용합니다.

<p align="left">
  <img width="250" alt="스크린샷1" src="https://user-images.githubusercontent.com/81131715/206367080-f44c6f90-c21c-4d4d-9927-ef5992001faa.gif">
</p>


## ✅ 테스트방법
- 회원가입 플로우로 실행하시면 됩니다.
